### PR TITLE
Update slack URL

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -33,7 +33,7 @@
 								</a>
 							</li>
 							<li>
-								<a href="https://publicslack.com/slacks/gardener-cloud/invites/new" target="_blank">
+								<a href="https://kubernetes.slack.com/messages/gardener" target="_blank">
 									<button class="u-pull-right ">
 										<img src="images/Slack_RGB.svg" height="40">
 									</button>


### PR DESCRIPTION
We moved to the #gardener channel in the kubernetes slack workspace
https://kubernetes.slack.com/messages/gardener