### PR TITLE
Alban and Michael added, secure@sap.com added

### DIFF
--- a/security-release-process.md
+++ b/security-release-process.md
@@ -1,19 +1,21 @@
 # Gardener Security Release Process
 
-Gardener is a growing community of volunteers and users. The Gardener community has adopted this security disclosures and response policy to ensure we responsibly handle critical issues.
+Gardener is a growing community of volunteers and users. The Gardener community has adopted this security disclosure and response policy to ensure we responsibly handle critical issues.
 
 ## Gardener Security Team
 
 Security vulnerabilities should be handled quickly and sometimes privately. The primary goal of this process is to reduce the total time users are vulnerable to publicly known exploits. The Gardener Security Team is responsible for organizing the entire response including internal communication and external disclosure but will need help from relevant developers and release managers to successfully run this process. The initial Gardener Security Team will consist of volunteers subscribed to the private [Gardener Security](https://groups.google.com/forum/#!forum/gardener-security) mailing list. These are the people who have been involved in the initial discussion and volunteered:
 
 * Olaf Beier, (**[@olafbeier](https://github.com/olafbeier)**) 
+* Vasu Chandrasekhara, (**[@vasu1124](https://github.com/vasu1124)**)
+* Alban Crequy, (**[@alban](https://github.com/alban)**)
 * Norbert Hamann, (**[@norberthamann](https://github.com/norberthamann)**) 
 * Claudia H&ouml;lters, (**[@hoeltcl](https://github.com/hoeltcl)**)
 * Oliver Kling, (**[@oliverkling](https://github.com/oliverkling)**) 
-* Matthias Sohn, (**[@msohn](https://github.com/msohn)**)
-* Dirk Marwinski, (**[@marwinski](https://github.com/marwinski)**)
-* Vasu Chandrasekhara, (**[@vasu1124](https://github.com/vasu1124)**)
 * Vedran Lerenc, (**[@vlerenc](https://github.com/vlerenc)**)
+* Dirk Marwinski, (**[@marwinski](https://github.com/marwinski)**)
+* Michael Schubert, (**[@schu](https://github.com/shu)**)
+* Matthias Sohn, (**[@msohn](https://github.com/msohn)**)
 * Frederik Thormaehlen, (**[@ThormaehlenFred](https://github.com/ThormaehlenFred)**)
 
 
@@ -21,11 +23,11 @@ Security vulnerabilities should be handled quickly and sometimes privately. The 
 
 ### Private Disclosure Processes
 
-The Gardener community asks that all suspected vulnerabilities be privately and responsibly disclosed. If you've found a vulnerability or a potential vulnerability in Gardener please let us know via the Gardener Security mailing list [gardener-security@googlegroups.com](mailto:gardener-security@googlegroups.com). We'll send a confirmation e-mail to acknowledge your report, and we'll send an additional e-mail when we've identified the issue positively or negatively.
+The Gardener community asks that all suspected vulnerabilities be privately and responsibly disclosed. If you've found a vulnerability or a potential vulnerability in Gardener please let us know by writing an e-mail to [secure@sap.com](mailto:secure@sap.com). We'll send a confirmation e-mail to acknowledge your report, and we'll send an additional e-mail when we've identified the issue positively or negatively.
 
 ### Public Disclosure Processes
 
-If you know of a publicly disclosed security vulnerability please IMMEDIATELY e-mail to the Gardener Security mailing list [gardener-security@googlegroups.com](mailto:gardener-security@googlegroups.com) to inform the Gardener Security Team about the vulnerability so they may start the patch, release, and communication process.
+If you know of a publicly disclosed security vulnerability please IMMEDIATELY e-mail to [secure@sap.com](mailto:secure@sap.com) to inform the Gardener Security Team about the vulnerability so they may start the patch, release, and communication process.
 
 If possible the Gardener Security Team will ask the person making the public report if the issue can be handled via a private disclosure process (for example if the full exploit details have not yet been published). If the reporter denies the request for private disclosure, the Gardener Security Team will move swiftly with the fix and release process. In extreme cases GitHub can be asked to delete the issue but this generally isn't necessary and is unlikely to make a public disclosure less damaging.
 
@@ -35,29 +37,25 @@ For each vulnerability a member of the Gardener Security Team will volunteer to 
 
 ### Fix Team Organization
 
-These steps should be completed within the first 24 hours of disclosure.
-
 The Fix Lead will work quickly to identify relevant engineers from the affected projects and packages and CC those engineers into the disclosure thread. These selected developers are the Fix Team.
 The Fix Lead will give the Fix Team access to a private security repository to develop the fix.
 
 ### Fix Development Process
 
-These steps should be completed within the 1-7 days of Disclosure.
-
 The Fix Lead and the Fix Team will create a [CVSS](https://www.first.org/cvss/specification-document) using the [CVSS Calculator](https://www.first.org/cvss/calculator/3.0). The Fix Lead makes the final call on the calculated CVSS; it is better to move quickly than make the CVSS perfect.
 The Fix Team will notify the Fix Lead that work on the fix branch is complete once there are LGTMs on all commits in the private repository from one or more maintainers.
-If the CVSS score is under 7.0 (a [medium severity score](https://www.first.org/cvss/specification-document#i5)) the Fix Team can decide to slow the release process down in the face of holidays, developer bandwidth, etc. These decisions must be discussed on the the Gardener Security mailing list [gardener-security@googlegroups.com](mailto:gardener-security@googlegroups.com).
+If the CVSS score is under 7.0 (a [medium severity score](https://www.first.org/cvss/specification-document#i5)) the Fix Team can decide to slow the release process down in the face of holidays, developer bandwidth, etc. These decisions must be discussed on the Gardener Security mailing list [gardener-security@googlegroups.com](mailto:gardener-security@googlegroups.com).
 
 ### Fix Disclosure Process
 
 With the fix development underway, the Fix Lead needs to come up with an overall communication plan for the wider community. This Disclosure process should begin after the Fix Team has developed a Fix or mitigation so that a realistic time line can be communicated to users.
 
-Disclosure of Forthcoming Fix to Users (Completed within 1-7 days of Disclosure)
+Disclosure of Forthcoming Fix to Users 
 The Fix Lead will e-mail the Gardener mailing list [gardener@googlegroups.com](mailto:gardener@googlegroups.com) informing users that a security vulnerability has been disclosed and that a fix will be made available at YYYY-MM-DD HH:MM UTC in the future via this list. This time is the Release Date.
 The Fix Lead will include any mitigating steps users can take until a fix is available.
 The communication to users should be actionable. They should know when to block time to apply patches, understand exact mitigation steps, etc.
 
-### Fix Release Day (Completed within 1-21 days of Disclosure)
+### Fix Release Day
 
 The Release Managers will ensure all the binaries are built, publicly available, and functional before the Release Date. 
 The Release Managers will create a new patch release branch from the latest patch release tag + the fix from the security branch. As a practical example if v1.5.3 is the latest patch release in gardener.git a new branch will be created called v1.5.4 which includes only patches required to fix the issue.
@@ -69,7 +67,7 @@ The Fix Lead will remove the Fix Team from the private security repository.
 
 ### Retrospective
 
-These steps should be completed 1-3 days after the Release Date. The retrospective process [should be blameless](https://landing.google.com/sre/book/chapters/postmortem-culture.html).
+These steps should be completed after the Release Date. The retrospective process [should be blameless](https://landing.google.com/sre/book/chapters/postmortem-culture.html).
 
 The Fix Lead will send a retrospective of the process to the Gardener mailing list [gardener@googlegroups.com](mailto:gardener@googlegroups.com) including details on everyone involved, the time line of the process, links to relevant PRs that introduced the issue, if relevant, and any critiques of the response and release process.
 The Release Managers and Fix Team are also encouraged to send their own feedback on the process to  the Gardener mailing list [gardener@googlegroups.com](mailto:gardener@googlegroups.com). Honest critique is the only way we are going to get good at this as a community.


### PR DESCRIPTION
Alban and Michael joined the Gardener Security Mailing list in https://groups.google.com/forum/#!forum/gardener-security, and external parties should contact secure@sap.com instead of https://groups.google.com/forum/#!forum/gardener-security to be compliant. By the way I removed the strict time lines which are currently unrealistic to meet