### PR TITLE
Add section which refers to our pipeline documentation

### DIFF
--- a/website/documentation/045_contribute/10_code/14_cicd/_index.md
+++ b/website/documentation/045_contribute/10_code/14_cicd/_index.md
@@ -1,0 +1,26 @@
+---
+title: CI/CD
+type: contribute
+---
+
+In order to run continuous delivery workloads for all components contributing to the
+[Gardener](https://github.com/gardener) project, we operate a central service.
+
+Typical workloads encompass the execution of tests and builds of a variety of technologies,
+as well as building and publishing container images, typically containing build results.
+
+We are building our CI/CD offering around some principles:
+
+*  **container-native** - each workload is executed within a container
+   environment. Components may customise used container images
+* **automation** - pipelines are generated without manual interaction
+* **self-service** - components customise their pipelines by changing their sources
+* **standardisation**
+
+As an execution environment for CI/CD workloads, we use [Concourse](https://concourse-ci.org).
+We however abstract from the underlying "build executor" and instead offer a
+`Pipeline Definition Contract`, through which components declare their build pipelines as
+required.
+
+For more details, please see our [Build Pipeline Reference Manual](https://gardener.github.io/cc-utils/).
+


### PR DESCRIPTION
Adds a short section providing a brief overview for our CI/CD Pipeline and a link to our more detailed documentation.

I've added the content directly to the introduced .md file instead of providing a link as including the file in our repository and linking it would cause some (minor) headaches for us.