### PR TITLE
API reference documentation

### DIFF
--- a/website/documentation/070_api-reference/_index.md
+++ b/website/documentation/070_api-reference/_index.md
@@ -1,0 +1,21 @@
+---
+title: API Reference
+url: /api-reference/
+icon: navigation_tutorials.svg
+type: padding
+---
+
+# API Reference Documentation
+
+Bellow you can find reference documentation of the API for Gardener.
+
+## Gardener
+
+Gardener APIs are [Kubernetes-style](https://kubernetes.io/docs/reference/using-api/api-overview/) APIs for the life-cycle of a Kubernetes Cluster.
+
+Those APIs are divided into different groups:
+
+- [Core](core)
+- [Extensions](extensions)
+- [Settings](settings)
+- [Garden](garden)

--- a/website/documentation/070_api-reference/core/_index.md
+++ b/website/documentation/070_api-reference/core/_index.md
@@ -1,0 +1,6 @@
+---
+title: Core
+url: /api-reference/core
+remote: https://github.com/gardener/gardener/blob/master/hack/api-reference/core.md
+type: padding
+---

--- a/website/documentation/070_api-reference/extensions/_index.md
+++ b/website/documentation/070_api-reference/extensions/_index.md
@@ -1,0 +1,6 @@
+---
+title: Extensions
+url: /api-reference/extensions
+remote: https://github.com/gardener/gardener/blob/master/hack/api-reference/extensions.md
+type: padding
+---

--- a/website/documentation/070_api-reference/garden/_index.md
+++ b/website/documentation/070_api-reference/garden/_index.md
@@ -1,0 +1,6 @@
+---
+title: Garden
+url: /api-reference/garden
+remote: https://github.com/gardener/gardener/blob/master/hack/api-reference/garden.md
+type: padding
+---

--- a/website/documentation/070_api-reference/settings/_index.md
+++ b/website/documentation/070_api-reference/settings/_index.md
@@ -1,0 +1,6 @@
+---
+title: Settings
+url: /api-reference/settings
+remote: https://github.com/gardener/gardener/blob/master/hack/api-reference/settings.md
+type: padding
+---


### PR DESCRIPTION
This PR adds API reference documentation generated in the [Gardener](https://github.com/gardener/gardener/tree/master/hack/api-reference) and used as remote reference.

The documentation is divided into simple sections:

## Overview

![Screenshot_2019-09-25 API Reference Gardener Documentation](https://user-images.githubusercontent.com/33343952/65583086-44d68800-df87-11e9-9db9-0e86f0cad4a2.png)

## Core 

![Screenshot_2019-09-25 Core Gardener Documentation](https://user-images.githubusercontent.com/33343952/65583088-456f1e80-df87-11e9-8542-bde7447a84ba.png)

##  Extensions
![Screenshot_2019-09-25 Extensions Gardener Documentation](https://user-images.githubusercontent.com/33343952/65583090-456f1e80-df87-11e9-8620-e43722f0fded.png)

## Garden

![Screenshot_2019-09-25 Garden Gardener Documentation](https://user-images.githubusercontent.com/33343952/65583091-456f1e80-df87-11e9-8c26-4f7335713afa.png)

## Settings
![Screenshot_2019-09-25 Settings Gardener Documentation](https://user-images.githubusercontent.com/33343952/65583092-4607b500-df87-11e9-920e-1e8c4e663aa6.png)




