### PR TITLE
Existing VPCs must be in the same region like shoot

### DIFF
--- a/website/documentation/050-tutorials/content/howto/create-shoot-into-existing-aws-vpc/_index.md
+++ b/website/documentation/050-tutorials/content/howto/create-shoot-into-existing-aws-vpc/_index.md
@@ -12,7 +12,7 @@ aliases: ["readmore/shoot-into-existing-aws-vpc"]
 # Create a Shoot cluster into existing AWS VPC
 
 Gardener can create a new VPC, or use an existing one for your Shoot cluster. Depending on your needs you may want to create Shoot(s) into already created VPC. 
-The tutorial describes how to create a Shoot cluster into existing AWS VPC. The steps are identical for Alicloud, Azure, and GCP.
+The tutorial describes how to create a Shoot cluster into existing AWS VPC. The steps are identical for Alicloud, Azure, and GCP. Please note that the existing VPC must be in the same region like the shoot cluster that you want to deploy into the VPC.
 
 ## TL;DR
 
@@ -86,10 +86,12 @@ $ aws ec2 attach-internet-gateway --internet-gateway-id igw-c0a643a9 --vpc-id vp
 
 ## 4. Create the Shoot
 
-Prepare your Shoot manifest (you could check the [example manifests](https://github.com/gardener/gardener/tree/master/example)). Put your VPC id in `.spec.provider.infrastructureConfig.networks.vpc.id`:
+Prepare your Shoot manifest (you could check the [example manifests](https://github.com/gardener/gardener/tree/master/example)). Please make sure that you choose the
+region in which you had created the VPC earlier (step 2). Also, put your VPC ID in the `.spec.provider.infrastructureConfig.networks.vpc.id` field:
 
 ```yaml
 spec:
+  region: <aws-region-of-vpc>
   provider:
     type: aws
     infrastructureConfig:


### PR DESCRIPTION
**What this PR does / why we need it**:
Enhance documentation for deploying shoots into an existing VPC so that it contains information about the region details.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
