### PR TITLE
Update _index.md

### DIFF
--- a/website/documentation/guides/administer_shoots/x509_certificates/_index.md
+++ b/website/documentation/guides/administer_shoots/x509_certificates/_index.md
@@ -183,6 +183,8 @@ metadata:
   name: vuejs-ingress
   annotations:
     cert.gardener.cloud/purpose: managed
+    dns.gardener.cloud/class: garden
+  # dns.gardener.cloud/dnsnames: short.ingress.shoot.project.default-domain.gardener.cloud
   # cert.gardener.cloud/issuer: custom-issuer
 spec:
   tls:
@@ -216,6 +218,8 @@ metadata:
   name: vuejs-ingress
   annotations:
     cert.gardener.cloud/purpose: managed
+    dns.gardener.cloud/class: garden
+  # dns.gardener.cloud/dnsnames: short.ingress.shoot.project.default-domain.gardener.cloud
   # cert.gardener.cloud/issuer: custom-issuer
 spec:
   tls:

--- a/website/documentation/guides/administer_shoots/x509_certificates/_index.md
+++ b/website/documentation/guides/administer_shoots/x509_certificates/_index.md
@@ -184,7 +184,7 @@ metadata:
   annotations:
     cert.gardener.cloud/purpose: managed
     dns.gardener.cloud/class: garden
-  # dns.gardener.cloud/dnsnames: short.ingress.shoot.project.default-domain.gardener.cloud
+    dns.gardener.cloud/dnsnames: short.ingress.shoot.project.default-domain.gardener.cloud
   # cert.gardener.cloud/issuer: custom-issuer
 spec:
   tls:
@@ -219,7 +219,7 @@ metadata:
   annotations:
     cert.gardener.cloud/purpose: managed
     dns.gardener.cloud/class: garden
-  # dns.gardener.cloud/dnsnames: short.ingress.shoot.project.default-domain.gardener.cloud
+    dns.gardener.cloud/dnsnames: short.ingress.shoot.project.default-domain.gardener.cloud
   # cert.gardener.cloud/issuer: custom-issuer
 spec:
   tls:


### PR DESCRIPTION
Update ingress certificate request

**What this PR does / why we need it**:

It updates the documentation to reflect actual behaviour.

**Which issue(s) this PR fixes**:
Fixes #
After a little troubleshooting, it seems like the Ingress manifest don't trigger the DNSEntry manifest creation on the shoot without `dns.gardener.cloud/class: garden` and `dns.gardener.cloud/dnsnames: short.ingress.shoot.project.default-domain.gardener.cloud` annotations. 

**Special notes for your reviewer**:

Documentation update.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
