### PR TITLE
fix FM property type:doc->docs

### DIFF
--- a/.docforge/concepts.yaml
+++ b/.docforge/concepts.yaml
@@ -323,7 +323,7 @@ structure:
         frontmatter:
           title: Extending the Monitoring Stack
           remote: https://github.com/gardener/gardener/blob/master/docs/development/monitoring-stack.md
-          type: doc      
+          type: docs      
     - source: https://github.com/gardener/gardener/blob/master/docs/monitoring/operator_alerts.md
       properties:
         frontmatter:


### PR DESCRIPTION
**What this PR does / why we need it**:
The concepts/monitoring/extending has incorrect content type in the front-matter.
