### PR TITLE
Update _index.md

### DIFF
--- a/website/documentation/guides/applications/service-access/_index.md
+++ b/website/documentation/guides/applications/service-access/_index.md
@@ -21,8 +21,6 @@ This tutorial discusses how to enable access to your application from outside th
 North-South traffic). For internal communication amongst pods and services (sometimes called East-West traffic) there 
 are many examples, [here](https://cloudnativelabs.github.io/post/2017-04-18-kubernetes-networking/) is one brief example.
 
-You might need to enable the `Nginx Ingress` add-ons in your gardener dashboard to use some of those functionnality.
-
 ## Service Types
 A Service in Kubernetes is an abstraction defining a logical set of Pods and an access policy.  
 Services can be exposed in different ways by specifying a **type** in the service spec,
@@ -283,6 +281,8 @@ However this approach has its own limitation.
 You cannot configure a LoadBalancer to terminate HTTPS traffic, virtual hosts or path-based routing.   In Kubernetes 1.2 
 a separate resource called [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/#alternatives) is 
 introduced for this purpose.
+
+You might need to enable the `Nginx Ingress` add-ons in your gardener dashboard to use some of those functionnality.
 
 ### Why an Ingress
 

--- a/website/documentation/guides/applications/service-access/_index.md
+++ b/website/documentation/guides/applications/service-access/_index.md
@@ -21,6 +21,8 @@ This tutorial discusses how to enable access to your application from outside th
 North-South traffic). For internal communication amongst pods and services (sometimes called East-West traffic) there 
 are many examples, [here](https://cloudnativelabs.github.io/post/2017-04-18-kubernetes-networking/) is one brief example.
 
+You might need to enable the `Nginx Ingress` add-ons in your gardener dashboard to use some of those functionnality.
+
 ## Service Types
 A Service in Kubernetes is an abstraction defining a logical set of Pods and an access policy.  
 Services can be exposed in different ways by specifying a **type** in the service spec,


### PR DESCRIPTION
**What this PR does / why we need it**:
Add information on the `Access service from outside Kubernetes cluster` page

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
It's never mentioned that the use need to enable the nginx ingress to be able to access his cluster from outside of Kubernetes. Took me some time to realize why the process wasn't working until I turn it on.
