### PR TITLE
Update/Correct links 

### DIFF
--- a/website/community/_index.md
+++ b/website/community/_index.md
@@ -14,7 +14,7 @@ url: /community
             <span>Follow the latest project updates on Twitter</span>
         </div>
         <div class="four columns">
-            <a target="_blank" class="action-header" href="https://github.com/gardener/documentation/blob/master/CONTRIBUTING.md#weekly-meeting">
+            <a target="_blank" class="action-header" href="https://github.com/gardener/community/wiki/2021-Community-Call">
                 <!-- FIXME -->
                 <img src="https://gardener.cloud/images/lp/comms-community-meetings.svg"><span>Community Meetings</span>
             </a>


### PR DESCRIPTION
**What this PR does / why we need it**:
Redirect Community Meetings button to https://github.com/gardener/community/wiki/2021-Community-Call

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
NONE
```
