### PR TITLE
Remove Bouquet addon page

### DIFF
--- a/.docforge/concepts.yaml
+++ b/.docforge/concepts.yaml
@@ -36,13 +36,7 @@ structure:
           title: kubify
           remote: https://github.com/gardener/kubify/blob/master/README.md
           url: /components/kubify/
-    - name: 40_bouquet
-      source: https://github.com/gardener-attic/bouquet/blob/master/README.md
-      properties:
-        frontmatter:
-          title: Bouquet
-          remote: https://github.com/gardener/bouquet/blob/master/README.md
-          url: /components/bouquet/
+    
   - name: backup-restore
     nodes:
     - source: https://github.com/gardener/gardener/blob/master/docs/concepts/backup-restore.md


### PR DESCRIPTION
Remove https://gardener.cloud/components/bouquet/ page from the site

**What this PR does / why we need it**:
Remove https://gardener.cloud/components/bouquet/ page ( Bouquet addon is no more relevant)
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
NONE
```
