### PR TITLE
Remove custom short codes

### DIFF
--- a/website/documentation/060-curated-links/_index.md
+++ b/website/documentation/060-curated-links/_index.md
@@ -4,17 +4,6 @@ url: /curated-links
 icon: navigation_links.svg
 ---
 
-<div class="hero">
-    <div class="container reveal-fast" style="visibility:hidden">
-        <h1>Curated Links</h1>
-        <div class="preamble reveal-slow">
-           A curated list of Kubernetes resources and projects
-        </div>
-    </div>
-</div>
-
-<div class="padding">
-{{% md %}}
 A curated list of awesome kubernetes sources
 Inspired by [@sindresorhus' awesome](https://github.com/sindresorhus/awesome)
 
@@ -105,6 +94,3 @@ Inspired by [@sindresorhus' awesome](https://github.com/sindresorhus/awesome)
 Contributions are most welcome!
 
 This list is just getting started, please contribute to make it super awesome.
-{{% /md %}}
-
-</div>

--- a/website/documentation/contribute/10_code/_index.md
+++ b/website/documentation/contribute/10_code/_index.md
@@ -2,24 +2,9 @@
 title: Code
 url: /contribute/code/
 ---
-<div class="hero">
-    <div class="container reveal-fast" style="visibility:hidden">
-        <h1><i class="fa fa-code-fork"></i> Contributing Code</h1>
-        <div class="preamble reveal-slow">
-            How to Contribute to the Open Source Project Gardener
-        </div>
-    </div>
-</div>
-
-<div class="padding highlightable  body-inner-wrapper">
-{{% md %}}
-
 
 You are welcome to **contribute code** to Gardener in order to fix a bug or to implement a new feature.
 
 The following rules govern code contributions:
 * Contributions must be licensed under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0)
 * You need to sign the Contributor License Agreement. We are using *[CLA assistant](https://cla-assistant.io/)* providing a click-through workflow for accepting the CLA. For company contributors additionally the company needs to sign a corporate license agreement. See the following sections for details.
-
-{{% /md %}}
-</div>

--- a/website/documentation/guides/administer_shoots/maintain-shoot/_index.md
+++ b/website/documentation/guides/administer_shoots/maintain-shoot/_index.md
@@ -13,11 +13,11 @@ Day two operations for shoot clusters are related to:
 * The Kubernetes version of the control plane and the worker nodes
 * the operating system version of the worker nodes
 
-{{% notice note %}}
+{{% alert color="info" %}}
 <p>
 When referring to an update of the "operating system version" in this document, the update of the machine image of the shoot cluster's worker nodes is meant. For example, Amazon Machine Images (AMI) for AWS.
 </p>
-{{% /notice %}}
+{{% /alert %}}
 
 
 The following table summarizes what options Gardener offers to maintain these versions:
@@ -77,11 +77,11 @@ To trigger updates during the maintenance window automatically, Gardener offers 
 
 If you don’t want to wait for the next maintenance window, you can annotate the shoot cluster specification with `shoot.gardener.cloud/operation: maintain`. Gardener then checks immediately if there’s an auto-update or a forceful update needed.
 
-{{% notice info %}}
+{{% alert color="info" %}}
 <p>
 Forceful version updates are even executed if the auto-update for the Kubernetes version, or the auto-update for the machine image version is deactivated (set to `false`).
 </p>
-{{% /notice %}}
+{{% /alert %}}
 
 With expiration dates, administrators can give shoot cluster owners more time for testing before the actual version update happens, which allows smoother transitions to new versions.
 
@@ -97,11 +97,11 @@ The bigger the delta of the Kubernetes source version and the Kubernetes target 
 
 Gardener doesn’t support automatic updates of nonconsecutive minor versions, because Kubernetes doesn’t guarantee updateability in this case. However, multiple minor version updates are possible if not only the minor source version is expired, but also the minor target version is expired. Gardener then updates the Kubernetes version first to the expired target version, and waits for the next maintenance window to update this version to the next minor target version.
 
-{{% notice warning %}}
+{{% alert color="warning" title="Warning" %}}
 <p>
 The administrator who maintains the `CloudProfile` has to ensure that the list of Kubernetes versions consists of consecutive minor versions, for example, from `1.10.x` to `1.11.y`. If the minor version increases in bigger steps, for example, from `1.10.x` to `1.12.y`, shoot cluster updates fail during the maintenance window. 
 </p>
-{{% /notice %}}
+{{% /alert %}}
 
 ## Manual Updates
 
@@ -114,11 +114,11 @@ Choosing the latter option, causes changes to the cluster (for example, node poo
 
 More information: [Confine Specification Changes/Update Roll Out](https://github.com/gardener/gardener/blob/master/docs/usage/shoot_maintenance.md#confine-specification-changesupdates-roll-out).
 
-{{% notice warning %}}
+{{% alert color="warning" title="Warning" %}}
 <p>
 Before applying such update on minor or major releases, operators should check for all the breaking changes introduced in the target Kubernetes release changelog.
 </p>
-{{% /notice %}}
+{{% /alert %}}
 
 ## Examples
 

--- a/website/documentation/guides/applications/insecure-configuration/_index.md
+++ b/website/documentation/guides/applications/insecure-configuration/_index.md
@@ -7,8 +7,7 @@ scope: operator
 ---
 
 # Auditing Kubernetes for Secure Setup
-
-{{% howto_img "" "./images/teaser.svg" %}}
+![teaser](./images/teaser.svg)
 
 ## Increasing the Security of all Gardener Stakeholders
 In summer 2018, the [Gardener project team](https://github.com/gardener/gardener) asked [Kinvolk](https://kinvolk.io/) to execute several penetration tests in its role as third-party contractor. The goal of this ongoing work is to increase the security of
@@ -78,7 +77,7 @@ The API server will check whether the client certificate presented by kubectl, k
 is really signed by the configured certificate authority for clients.
 
 
-{{% howto_img "The API server can have many clients of various kinds" "./images/image3.png" %}}
+![](./images/image3.png)*The API server can have many clients of various kinds*<br/><br/><br/>
 
 However, it is possible to configure the API server differently for use with an intermediate authenticating proxy. The
 proxy will authenticate the client with its own custom method and then issue HTTP requests to the API server with
@@ -91,16 +90,12 @@ additional HTTP headers specifying the user name and group name. The API server 
 --requestheader-group-headers=X-Remote-Group
 ```
 
-
-{{% howto_img "API server clients can reach the API server through an authenticating proxy" "./images/image2.png" %}}
-
-
+![](./images/image2.png)*API server clients can reach the API server through an authenticating proxy*<br/><br/><br/>
 
 So far, so good. But what happens if malicious user “Mallory” tries to connect directly to the API server and reuses
 the HTTP headers to pretend to be someone else?
 
-
-{{% howto_img "What happens when a client bypasses the proxy, connecting directly to the API server?" "./images/image8.png" %}}
+![](./images/image8.png)*What happens when a client bypasses the proxy, connecting directly to the API server?*<br/><br/><br/>
 
 
 With a correct configuration, Mallory’s kubeconfig will have a certificate signed by the API server certificate authority
@@ -127,8 +122,7 @@ The API server is a central component of Kubernetes and many components initiate
 running on worker nodes. Most of the requests from those clients will end up updating Kubernetes objects (pods, services,
 deployments, and so on) in the etcd database but the API server usually does not need to initiate TCP connections itself.
 
-
-{{% howto_img "The API server is mostly a component that receives requests" "./images/image7.png" %}}
+![](./images/image7.png)*The API server is mostly a component that receives requests*<br/><br/><br/>
 
 
 However, there are exceptions. Some `kubectl` commands will trigger the API server to open a new
@@ -140,10 +134,7 @@ Basically, the Kubelet is telling the API server to get the streams from CRI its
 redirection from the Kubelet will only change the port and path from the URL; the IP address will not be changed because
 the Kubelet and the CRI component run on the same worker node.
 
-
-
-{{% howto_img "But the API server also initiates some connections, for example, to worker nodes" "./images/image1.png" %}}
-
+![](./images/image1.png)*But the API server also initiates some connections, for example, to worker nodes*<br/><br/><br/>
 
 It’s often quite easy for users of a Kubernetes cluster to get access to worker nodes and tamper with the Kubelet. They
 could be given explicit SSH access or they could be given a kubeconfig with enough privileges to create privileged pods
@@ -160,10 +151,7 @@ What would happen if a user was tampering with the Kubelet to make it maliciousl
 a different random endpoint? Most likely the given endpoint would not speak the streaming server protocol, so there would
 be an error. However, the full HTTP payload from the endpoint is included in the error message printed by kubectl exec.
 
-
-
-{{% howto_img "The API server is tricked to connect to other components" "./images/image6.png" %}}
-
+![](./images/image6.png)*The API server is tricked to connect to other components*<br/><br/><br/>
 
 The impact of this issue depends on the specific setup. But in many configurations, we could find a metadata service
 (such as the [AWS metadata service](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html))
@@ -205,8 +193,7 @@ plane, but also to a Grafana instance that is used to gather data from their Kub
 plane is managed and users don’t have access to the nodes that it runs. They can only access the API server and Grafana
 via a load balancer. The internal network of the control plane is therefore hidden to users.
 
-
-{{% howto_img "Prometheus and Grafana can be used to monitor worker nodes" "./images/image5.png" %}}
+![](./images/image5.png)*Prometheus and Grafana can be used to monitor worker nodes*<br/><br/><br/>
 
 
 Unfortunately, that setup was not protecting the control plane network from nosy users. By configuring a new custom
@@ -214,11 +201,9 @@ data source in Grafana, we could send HTTP requests to target the control plane 
 service. The reply payload is not displayed on the Grafana Web UI but it is possible to access it from the debugging
 console of the Chrome browser.
 
+![](./images/image9.png)*Credentials can be retrieved from the debugging console of Chrome*<br/><br/><br/>
 
-{{% howto_img "Credentials can be retrieved from the debugging console of Chrome" "./images/image9.png" %}}
-
-
-{{% howto_img "Adding a Grafana data source is a way to issue HTTP requests to arbitrary targets" "./images/image4.png" %}}
+![](./images/image4.png)*Adding a Grafana data source is a way to issue HTTP requests to arbitrary targets*<br/><br/><br/>
 
 In that installation, users could get the “user-data” for the seed cluster from the metadata service and retrieve a
 kubeconfig for that Kubernetes cluster.

--- a/website/documentation/tutorials/shoot_istio_dns_certs/_index.md
+++ b/website/documentation/tutorials/shoot_istio_dns_certs/_index.md
@@ -22,9 +22,9 @@ Here are some pre-pointers that you will need to go deeper:
 * [Tutorial Domain Names](https://gardener.cloud/docs/guides/administer_shoots/dns_names/)
 * [Tutorial Certificates](https://gardener.cloud/docs/guides/administer_shoots/request_cert/)
 
-{{% notice tip %}}
+{{% alert title="Tip" color="primary" %}}
 <p>If you try my instructions and fail, then read the alternative title of this tutorial as "Shoot yourself in foot with Gardener, custom Domains, Istio and Certificates".</p>
-{{% /notice %}}
+{{% /alert %}}
 
 ## First Things First
 
@@ -62,9 +62,9 @@ Our [External DNS Manager](https://github.com/gardener/external-dns-management/)
 ## Prepare Gardener Extensions
 I now need to prepare the Gardener extensions `shoot-dns-service` and `shoot-cert-service` and set the parameters accordingly.
 
-{{% notice note %}}
+{{% alert color="info" %}}
 <p>Please note, that the availability of Gardener Extensions depends on how your administrator has configured the Gardener landscape. Please contact your Gardener administrator in case you experience any issues during activation.</p>
-{{% /notice %}}
+{{% /alert %}}
 
 The following snipplet allows Gardener to manage my entire custom domain, whereas with the `include:` attribute I restrict all dynamic entries under the subdomain `gsicdc.mydomain.io`:
 
@@ -96,9 +96,9 @@ The next snipplet allows Gardener to manage certificates automatically from *[Le
             server: 'https://acme-staging-v02.api.letsencrypt.org/directory'
 ```
 
-{{% notice note %}}
+{{% alert color="info" %}}
 <p>Adjust the snipplets with your parameters (don't forget your email). And please use the mydomain-staging issuer while you are testing and learning. Otherwise, Let's Encrypt will rate limit your frequent requests and you can wait a week until you can continue.</p>
-{{% /notice %}}
+{{% /alert %}}
 
 References for [Let's Encrypt](https://letsencrypt.org):
 * [Rate limit](https://letsencrypt.org/docs/rate-limits/)
@@ -226,9 +226,9 @@ With these annotations three things now happen automagically:
 2. The [Certificate Mangement](https://gardener.cloud/docs/concepts/networking/cert-managment/) picks up the request as well and initates a DNS01 protocol exchange with Let's Encrypt; using the staging environment referred to with the issuer behind `mydomain-staging`.
 3. After aproximately 70sec (give and take) you will receive the wildcard certificate in the `wildcard-tls` secret in the namespace `istio-system`. 
 
-{{% notice note %}}
+{{% alert color="info" %}}
 <p>Notice, that the namespace for the certificate secret is often the cause of many troubeshooting sessions: the secret must reside in the same namespace of the gateway.</p>
-{{% /notice %}}
+{{% /alert %}}
 
 Here is the istio-install script:
 ```bash
@@ -294,9 +294,9 @@ brew install httpie
 
 ## Ingress to your service
 
-{{% notice note %}}
+{{% alert color="info" %}}
 <p>Networking is a central part of Kubernetes, but it can be challenging to understand exactly how it is expected to work. You should learn about Kubernetes networking, and first try to debug problems yourself. With a solid managed cluster from Gardener, it is always PEBCAK!</p>
-{{% /notice %}}
+{{% /alert %}}
 
 Kubernetes Ingress is a subject that is evolving to much broader standard. Please watch [Evolving the Kubernetes Ingress APIs to GA and Beyond](https://www.youtube.com/watch?v=cduG0FrjdJA) for a good introduction. In this example, I did not want to use the Kubernetes `Ingress` compatibility option of Istio. Instead, I used `VirtualService` and `Gateway` from the Istio's API group `networking.istio.io/v1beta1` directly, and enabled istio-injection generically for the namespace.
 
@@ -441,9 +441,9 @@ $ curl -k https://httpbin.gsicdc.mydomain.io/ip
 Quod erat demonstrandum.
 The proof of exchanging the issuer is now left to the reader. 
 
-{{% notice tip %}}
+{{% alert title="Tip" color="primary" %}}
 <p>Remember that the certificate is actually not valid because it is issued from the Let's encrypt staging environment. Thus, we needed "curl -k" or "http --verify no".</p>
-{{% /notice %}}
+{{% /alert %}}
 
 Hint: use the interactive k9s tool.
 ![k9s](./k9s.png)


### PR DESCRIPTION
**What this PR does / why we need it**:
1. Removed `{{% md %}}` short code because there is no value in supporting it
2.  ```{{% howto_img "description" "image_path" %}}```  is replaced by ```![](image_path)*description*<br/><br/><br/>```
3.  ```{{% notice note %}}``` is replaced by Docsy supported ```{{% alert color="info" %}}```
4.  ```{{% notice info %}}``` is replaced by  Docsy supported ```{{% alert color="info" %}}```
5.  ```{{% notice warning %}}``` is replaced by Docsy supported ```{{% alert color="warning" title="Warning" %}}```
6.  ```{{% notice tip %}}``` is replaced by Docsy supported ```{{% alert title="Tip" color="primary" %}}```

This PR will also fix the broken images in the changed files.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@JordanJordanov 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The Documentation now uses only Docsy supported short codes
```
