### PR TITLE
Removed featureflag link

### DIFF
--- a/website/blog/2019_week_21_2/Feature-Flags-in-Kubernetes-Applications.md
+++ b/website/blog/2019_week_21_2/Feature-Flags-in-Kubernetes-Applications.md
@@ -24,6 +24,4 @@ Possible Use Cases
  - change timeouts in production
  - toggle on/off some special verification
 
-..read some more on [Feature Flags for App](https://github.com/gardener-samples/kube-featureflag/blob/master/README.md).
-
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes a link pointing towards the removed kube-featureflag page.
**Which issue(s) this PR fixes**:
Fixes #229 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
NONE
```
