### PR TITLE
Remove set -u flag from the check-manifet script

### DIFF
--- a/.ci/check-manifest
+++ b/.ci/check-manifest
@@ -8,7 +8,7 @@
 # GIT_OAUTH_TOKEN - used for fetch the content from Github
 # MANIFEST_ORG - used to replace the manifest org to this one. If does not exist, the script will try to get the org from .ci/userlogin
 # MANIFEST_VERSION - used to replace the manifest version to this one. If does not exist, the script will try to get the version from .ci/branch
-set -eu
+set -e
 
 if [[ $(uname) == 'Darwin' ]]; then
   READLINK_BIN="greadlink"


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove set -u flag from the check-manifet script

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
None
```
