### PR TITLE
Fix Repo path variable in the check-manifest script

### DIFF
--- a/.ci/check-manifest
+++ b/.ci/check-manifest
@@ -46,10 +46,10 @@ if [[ ! -z "${MANIFEST_ORG}" ]] && [[ ! -z "${MANIFEST_VERSION}" ]]; then
   echo "Retrieving org and mainBranch from env vars"
   org=${MANIFEST_ORG}
   mainBranch=${MANIFEST_VERSION}
-elif [[ -f "${docforge_repo_path}/.git/userlogin" ]] && [[ -f "${docforge_repo_path}/.git/branch" ]]; then
-  echo "Retrieving org and mainBranch from ${docforge_repo_path}/.git"
-  org=$(cat "${docforge_repo_path}/.git/userlogin")
-  mainBranch=$(cat "${docforge_repo_path}/.git/branch")
+elif [[ -f "${repoPath}/.git/userlogin" ]] && [[ -f "${repoPath}/.git/branch" ]]; then
+  echo "Retrieving org and mainBranch from ${repoPath}/.git"
+  org=$(cat "${repoPath}/.git/userlogin")
+  mainBranch=$(cat "${repoPath}/.git/branch")
 else
   echo "Using default org and mainBranch"
   org="gardener"


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix Repo path variable in the check-manifest script

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
None
```
