### PR TITLE
Run check-manifest script only if there is diff in the documentation

### DIFF
--- a/.ci/check-manifest
+++ b/.ci/check-manifest
@@ -6,7 +6,24 @@
 
 # For the integration-test step the following environment variables are used:
 # GIT_OAUTH_TOKEN - used for fetch the content from Github
+# CHECKED_DIRS - the directories which will be checked for diff against origin/master. If Diff exists then the checks will be triggered.
+# otherwise the script will exist with status code 0
 set -e
+
+diffExist=false
+
+for arg in "$@"; do
+  diff=$(git diff origin/master --name-only | grep "^${arg}" || true)
+  if [[ ! -z "${diff}" ]] ; then
+    diffExist=true
+    break
+  fi
+done
+
+if [[ "${diffExist}" = false ]] ; then
+    echo "There is no diff in the checked directories so the script exits successfully"
+    exit 0
+fi
 
 if [[ $(uname) == 'Darwin' ]]; then
   READLINK_BIN="greadlink"

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -9,6 +9,10 @@ documentation:
     steps:
       check-manifest:
         image: "eu.gcr.io/gardener-project/gardener-website-generator:stable"
+        execute:
+          - check-manifest
+          - .docforge/
+          - website/
         cache_paths: ['.docforge']
   jobs:
     release:

--- a/Makefile
+++ b/Makefile
@@ -28,4 +28,4 @@ stop:
 
 .PHONY: check-manifest
 check-manifest:
-	@.ci/check-manifest
+	@.ci/check-manifest .docforge/ website/


### PR DESCRIPTION
**What this PR does / why we need it**:
Run check-manifest script only if there is diff in the documentation

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
None
```
