### PR TITLE
Add delimeter in the check-manifest script for diffDirs

### DIFF
--- a/.ci/check-manifest
+++ b/.ci/check-manifest
@@ -72,7 +72,7 @@ echo "CONFIG_PATH= ${CONFIG_PATH}"
 cd ${REPO_PATH}
 diffExist=false
 
-for dir in ${DIFF_DIRS}; do
+for dir in $(echo $DIFF_DIRS | tr ";" "\n"); do
   diff=$(git diff origin/master --name-only | grep "^${dir}" || true)
   if [[ ! -z "${diff}" ]] ; then
     diffExist=true

--- a/.ci/check-manifest-entrypoint
+++ b/.ci/check-manifest-entrypoint
@@ -12,7 +12,7 @@ fi
 
 repoPath="$(${READLINK_BIN} -f $(dirname ${0})/..)"
 manifestPath="${repoPath}/.docforge/website.yaml"
-diffDirs=".docforge/ website/"
+diffDirs=".docforge/;website/"
 configPath="${repoPath}/.ci/check-manifest-config"
 scriptPath="${repoPath}/.ci/check-manifest"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Add delimeter in the check-manifest script for diffDirs

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
None
```
