### PR TITLE
Renamed MCM FAQ

### DIFF
--- a/.docforge/documentation/other-components.yaml
+++ b/.docforge/documentation/other-components.yaml
@@ -6,6 +6,14 @@ structure:
       description: Declarative way of managing machines for Kubernetes cluster
   nodesSelector:
     path: https://github.com/gardener/machine-controller-manager/blob/DEFAULT_BRANCH/.docforge/manifest.yaml
+  nodes:
+  - name: docs
+    nodes:
+    - source: https://github.com/gardener/machine-controller-manager/blob/master/docs/FAQ.md
+      properties:
+        frontmatter:
+          title: Machine Controller Manager FAQ
+          description: Commonly asked questions about MCM
 - name: etcd-druid
   properties:
     frontmatter:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR renames the Machine Controller Manager FAQ section to a less misleading name. 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
NONE
```
