### PR TITLE
Adding gardenctl2 documentation

### DIFF
--- a/.docforge/documentation/documentation.yaml
+++ b/.docforge/documentation/documentation.yaml
@@ -25,14 +25,13 @@ structure:
       index: true
   nodesSelector:
     path: https://github.com/gardener/dashboard/blob/DEFAULT_BRANCH/.docforge/manifest.yaml
-- name: gardenctl
+- name: gardenctl-v2
   properties:
     frontmatter:
-      title: Gardenctl
+      title: Gardenctl V2
       description: The command line interface to control your clusters
       weight: 4
-  nodesSelector:
-    path: https://github.com/gardener/gardenctl/blob/DEFAULT_BRANCH/.docforge/manifest.yaml
+  source: https://github.com/gardener/gardenctl-v2/blob/DEFAULT_BRANCH/README.md
 - name: faq
   properties:
     frontmatter:


### PR DESCRIPTION
**What this PR does / why we need it**:
Replacing gardenctl with gardenctl-v2 documentation

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
Replacing gardenctl with gardenctl-v2 documentation
```
