### PR TITLE
Ambiguous argument origin/master fix

### DIFF
--- a/.ci/check-manifest
+++ b/.ci/check-manifest
@@ -66,7 +66,7 @@ cd "${REPO_PATH}"
 diffExist=false
 
 for dir in $(echo "$DIFF_DIRS" | tr ";" "\n"); do
-  diff=$(git diff origin/master --name-only | grep "^${dir}" || true)
+  diff=$(git diff origin/master --name-only -- | grep "^${dir}" || true)
   if [[ -n "${diff}" ]]; then
     diffExist=true
     break


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix error on older git version(2.30.2) - fatal: ambiguous argument 'origin/master'


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
NONE
```
