### PR TITLE
Removed gardenctl shell command usage for node debugging

### DIFF
--- a/website/documentation/guides/monitoring_and_troubleshooting/shell-to-node/_index.md
+++ b/website/documentation/guides/monitoring_and_troubleshooting/shell-to-node/_index.md
@@ -21,7 +21,6 @@ This guide only covers how to get access to the host, but does not cover trouble
 - [Get a Shell to an Operational Cluster Node](#get-a-shell-to-an-operational-cluster-node)
   - [Gardener Dashboard](#gardener-dashboard)
     - [Result](#result)
-  - [gardenctl shell](#gardenctl-shell)
   - [Gardener Ops Toolbelt](#gardener-ops-toolbelt)
   - [Custom Root Pod](#custom-root-pod)
 - [SSH Access to a Node That Failed to Join the Cluster](#ssh-access-to-a-node-that-failed-to-join-the-cluster)
@@ -72,33 +71,6 @@ In the default image used by the Dashboard, it is under `/hostroot`.
 
 <img style="margin-left:0"  alt="Dashboard terminal pod configuration" src="./images/3da659e9cc4744a2ad3e1c6a50d39c04.png"/>
 <br>
-
-### gardenctl shell
-
-**Prerequisite**: `kubectl` and [gardenctl are available and configured](https://github.com/gardener/gardenctl).
-
-1. First, target a Garden cluster containing all the Shoot definitions.
-
-```
-$ gardenctl target garden <target-garden>
-```
-
-2. Target an available Shoot by name. 
-This sets up the context and configures the `kubeconfig` file of the Shoot cluster.
-Subsequent commands will execute in this context.
-```
-$ gardenctl target shoot <target-shoot>
-```
-
-3. Get the nodes of the Shoot cluster.
-```
-$ gardenctl kubectl get nodes 
-```
-
-4. Pick a node name from the list above and get a root shell access to it.
-```
-$ gardenctl shell <target-node>
-```
 
 ### Gardener Ops Toolbelt
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The official documentation still supports usage of `gardenctl shell` command for node debugging. 
This is no more supported with gardenctl-v2.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Documentation for shell access to a node is updated with removal of section on using `gardenctl shell` command as it is no more supported with gardecntl-v2
```
