### PR TITLE
Added note on using terms in the documentation consistently

### DIFF
--- a/website/documentation/contribute/20_documentation/20_formatting_guide/_index.md
+++ b/website/documentation/contribute/20_documentation/20_formatting_guide/_index.md
@@ -39,10 +39,14 @@ leads to an awkward construction.
 |  Do  | Don't |
 |:---|:---|
 | The `Pod` has two containers.   | The pod has two containers.    |
-| The `Deployment` is responsible for ...   |  The Deployment object is responsible for ...    |
+| The `Deployment` is responsible for...   |  The Deployment object is responsible for...    |
 | A `PodList` is a list of Pods. | A Pod List is a list of pods.  |
 | The `gardener-control-manager` has control loops... | The gardener-control-manager has control loops...|
 | The `gardenlet` starts up with a bootstrap `kubeconfig` having a bootstrap token that allows to create `CertificateSigningRequest` (CSR) resources. | The gardenlet starts up with a bootstrap kubeconfig having a bootstrap token that allows to create CertificateSigningRequest (CSR) resources. |
+
+{{% alert color="info"  title="Note" %}}
+Due to the way the website is built from content taken from different repositories, when editing or updating already existing documentation, you should follow the style used in the topic. When contributing new documentation, follow the guidelines outlined in this guide.
+{{% /alert %}}
 
 ### New Terms and Emphasis
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a note regarding the consistent use of terms and object names in the documentation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement documentation
NONE
```
