### PR TITLE
Renamed Gardener Extensions section

### DIFF
--- a/.docforge/documentation/documentation.yaml
+++ b/.docforge/documentation/documentation.yaml
@@ -11,7 +11,7 @@ structure:
 - name: extensions
   properties:
     frontmatter:
-      title: Gardener Extensions
+      title: Extensions
       description: The infrastructure, networking, OS and other extension components for Gardener
       weight: 2
   nodesSelector:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR renames the "Gardener Extensions" section in the public website to "Extensions".

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
NONE
```
