### PR TITLE
Added etcd-backup-restore manifest

### DIFF
--- a/.docforge/documentation/other-components.yaml
+++ b/.docforge/documentation/other-components.yaml
@@ -5,3 +5,6 @@ structure:
 - name: etcd-druid
   nodesSelector:
     path: https://github.com/gardener/etcd-druid/blob/DEFAULT_BRANCH/.docforge/manifest.yaml
+- name: etcd-backup-restore
+  nodesSelector:
+    path: https://github.com/gardener/etcd-backup-restore/blob/DEFAULT_BRANCH/.docforge/manifest.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the etcd-backup-restore manifest created in the [personadocs PR](https://github.com/gardener/etcd-backup-restore/pull/641) to the public website.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
-Added the etcd-backup-restore repository to the public website.
```
