### PR TITLE
Updated Contributor's Guide and added topic about updating the manifest

### DIFF
--- a/website/documentation/contribute/_index.md
+++ b/website/documentation/contribute/_index.md
@@ -85,6 +85,10 @@ We kindly ask you to follow the [Pull Request Checklist](#pull-request-checklist
 
 If you want to contribute bigger changes to Gardener, such as when introducing new API resources and their corresponding controllers, or implementing an approved [Gardener Enhancement Proposal](https://github.com/gardener/gardener/tree/master/docs/proposals), follow the guidelines outlined in [Contributing Bigger Changes](./code/contributing-bigger-changes/_index.md).
 
+## Adding Already Existing Documentation
+
+If you want to add documentation that already exists on GitHub to the website, you should update the central manifest instead of duplicating the content. To find out how to do that, see [Adding Already Existing Documentation](./documentation/adding-existing-documentation/_index.md).
+
 ## Issues and Planning
 
 We use GitHub issues to track bugs and enhancement requests. Please provide as much context as possible when you open an issue. The information you provide must be comprehensive enough to reproduce that issue for the assignee. Therefore, contributors may use but aren't restricted to the issue template provided by the Gardener maintainers.

--- a/website/documentation/contribute/_index.md
+++ b/website/documentation/contribute/_index.md
@@ -49,7 +49,7 @@ Gardener uses GitHub to manage reviews of pull requests.
   Practices for Production
   Environments](http://peter.bourgon.org/go-in-production/#formatting-and-style).
 
-## Steps to Contribute
+### Steps to Contribute
 
 Should you wish to work on an issue, please claim it first by commenting on the GitHub issue that you want to work on it. This is to prevent duplicated efforts from contributors on the same issue.
 
@@ -57,7 +57,7 @@ If you have questions about one of the issues, with or without the tag, please c
 
 We kindly ask you to follow the [Pull Request Checklist](#pull-request-checklist) to ensure reviews can happen accordingly.
 
-## Pull Request Checklist
+### Pull Request Checklist
 
 * Branch from the master branch and, if needed, rebase to the current master branch before submitting your pull request. If it doesn't merge cleanly with master you may be asked to rebase your changes.
 
@@ -81,11 +81,11 @@ We kindly ask you to follow the [Pull Request Checklist](#pull-request-checklist
   * Set respective comments in your GitHub review to resolved.
   * Create a general PR comment to notify the reviewers that your amendments are ready for another round of review.
   
-## Contributing Bigger Changes
+### Contributing Bigger Changes
 
 If you want to contribute bigger changes to Gardener, such as when introducing new API resources and their corresponding controllers, or implementing an approved [Gardener Enhancement Proposal](https://github.com/gardener/gardener/tree/master/docs/proposals), follow the guidelines outlined in [Contributing Bigger Changes](./code/contributing-bigger-changes/_index.md).
 
-## Adding Already Existing Documentation
+### Adding Already Existing Documentation
 
 If you want to add documentation that already exists on GitHub to the website, you should update the central manifest instead of duplicating the content. To find out how to do that, see [Adding Already Existing Documentation](./documentation/adding-existing-documentation/_index.md).
 

--- a/website/documentation/contribute/documentation/adding-existing-documentation/_index.md
+++ b/website/documentation/contribute/documentation/adding-existing-documentation/_index.md
@@ -23,10 +23,9 @@ This short code snippet adds a whole repository worth of content and contains ex
 - `- dir: <dir-name>` - the name of the directory in the navigation path; must correspond to the folder name if it already exists in the main repo
 - `structure:` - required after using `dir`; shows that the following lines contain a file structure
 - `- file: _index.md` - creates an index file
-- `frontmatter:` - allows for manual setting/overwriting of the various properties a file can have
+- `frontmatter:` - allows for manual setting/overwriting of the various properties a file can have; for examples, see the [Style Guide](../style-guide/_index.md#front-matter)
 - `source: <link>` - where the content is located; in this case, a single file
 - `- fileTree: <link>` - where the content is located; in this case, a whole folder
-
 
 ## Adding Existing Documentation
 

--- a/website/documentation/contribute/documentation/adding-existing-documentation/_index.md
+++ b/website/documentation/contribute/documentation/adding-existing-documentation/_index.md
@@ -1,6 +1,5 @@
 ---
 title: Adding Already Existing Documentation
-description: Adding external Github documentation via manifest changes
 ---
 
 ## Overview
@@ -12,12 +11,11 @@ Sample codeblock:
 - dir: machine-controller-manager
   structure:
   - file: _index.md
-    properties:
-      frontmatter:
-        title: Machine Controller Manager
-        weight: 1
-        description: Declarative way of managing machines for Kubernetes cluster
-    source:  https://github.com/gardener/machine-controller-manager/blob/DEFAULT_BRANCH/README.md
+    frontmatter:
+      title: Machine Controller Manager
+      weight: 1
+      description: Declarative way of managing machines for Kubernetes cluster
+    source: https://github.com/gardener/machine-controller-manager/blob/DEFAULT_BRANCH/README.md
   - fileTree: https://github.com/gardener/machine-controller-manager/tree/DEFAULT_BRANCH/docs
 ```
 
@@ -25,7 +23,7 @@ This short code snippet adds a whole repository worth of content and contains ex
 - `- dir: <dir-name>` - the name of the directory in the navigation path; must correspond to the folder name if it already exists in the main repo
 - `structure:` - required after using `dir`; shows that the following lines contain a file structure
 - `- file: _index.md` - creates an index file
-- `properties:` - allows for manual setting/overwriting of the various properties a file can have
+- `frontmatter:` - allows for manual setting/overwriting of the various properties a file can have
 - `source: <link>` - where the content is located; in this case, a single file
 - `- fileTree: <link>` - where the content is located; in this case, a whole folder
 
@@ -73,7 +71,15 @@ You can add a single topic to the website by providing a link to it in the manif
 You can also add multiple topics to the website at once.
 
 {{% alert color="info"  title="Note" %}}
-If the content you want to add does not have an `_index.md` file in it, it won't show up as a single section on the website.
+If the content you want to add does not have an `_index.md` file in it, it won't show up as a single section on the website. You can fix this by adding the following after the `structure:` element:
+
+```yaml
+- file: _index.md
+  frontmatter:
+    title: <topic-name>
+    description: <topic-description>
+    weight: <weight>
+```
 {{% /alert %}}
 
 #### Through a Folder
@@ -99,11 +105,6 @@ If the content you want to add does not have an `_index.md` file in it, it won't
 ```yaml
 - dir: <dir-name>
   structure:
-  - file: _index.md
-    frontmatter:
-      title: <topic-name>
-      description: <topic-description>
-      weight: <weight>
   - manifest: https://github.com/<path>/manifest.yaml
 ```
 
@@ -113,11 +114,6 @@ If the content you want to add does not have an `_index.md` file in it, it won't
 ```yaml
 - dir: extensions
   structure:
-  - file: _index.md
-    frontmatter:
-      title: List of Extensions
-      description: The infrastructure, networking, OS and other extension components for Gardener
-      weight: 2
   - manifest: https://github.com/gardener/documentation/blob/master/.docforge/documentation/gardener-extensions/gardener-extensions.yaml
 ```
 </details>

--- a/website/documentation/contribute/documentation/adding-existing-documentation/_index.md
+++ b/website/documentation/contribute/documentation/adding-existing-documentation/_index.md
@@ -20,12 +20,14 @@ Sample codeblock:
 ```
 
 This short code snippet adds a whole repository worth of content and contains examples of some of the most important elements:
-- `- dir: <dir-name>` - the name of the directory in the navigation path; must correspond to the folder name if it already exists in the main repo
+- `- dir: <dir-name>` - the name of the directory in the navigation path
 - `structure:` - required after using `dir`; shows that the following lines contain a file structure
-- `- file: _index.md` - creates an index file
-- `frontmatter:` - allows for manual setting/overwriting of the various properties a file can have; for examples, see the [Style Guide](../style-guide/_index.md#front-matter)
-- `source: <link>` - where the content is located; in this case, a single file
-- `- fileTree: <link>` - where the content is located; in this case, a whole folder
+- `- file: _index.md` - the content will be a single file; also creates an index file
+- `frontmatter:` - allows for manual setting/overwriting of the various properties a file can have
+- `source: <link>` - where the content for the `file` element is located
+- `- fileTree: <link>` - the content will be a whole folder; also gives the location of the content
+
+Check the [Notes and Tips](#notes-and-tips) section for useful advice when making changes to the manifest files.
 
 ## Adding Existing Documentation
 
@@ -37,7 +39,7 @@ Proper identation is incredibly important, as yaml relies on it for nesting!
 
 ### Adding a Single File
 
-You can add a single topic to the website by providing a link to it in the manifest. You can chain multiple topics that way.
+You can add a single topic to the website by providing a link to it in the manifest.
 
 ```yaml
 - dir: <dir-name>
@@ -67,7 +69,7 @@ You can add a single topic to the website by providing a link to it in the manif
 
 ### Adding Multiple Files
 
-You can also add multiple topics to the website at once.
+You can also add multiple topics to the website at once, either through linking a whole folder or a manifest than contains the documentation structure.
 
 {{% alert color="info"  title="Note" %}}
 If the content you want to add does not have an `_index.md` file in it, it won't show up as a single section on the website. You can fix this by adding the following after the `structure:` element:
@@ -81,7 +83,7 @@ If the content you want to add does not have an `_index.md` file in it, it won't
 ```
 {{% /alert %}}
 
-#### Through a Folder
+#### Linking a Folder
 
 ```yaml
   - dir: <dir-name>
@@ -99,7 +101,7 @@ If the content you want to add does not have an `_index.md` file in it, it won't
 ```
 </details>
 
-#### Through a Manifest File
+#### Linking a Manifest File
 
 ```yaml
 - dir: <dir-name>
@@ -116,3 +118,9 @@ If the content you want to add does not have an `_index.md` file in it, it won't
   - manifest: https://github.com/gardener/documentation/blob/master/.docforge/documentation/gardener-extensions/gardener-extensions.yaml
 ```
 </details>
+
+### Notes and Tips
+
+- If you want to place a file inside of an already existing directory in the main repo, you need to create a `dir` element that matches its name. If one already exists, simply add your link to its `structure` element. 
+- You can chain multiple files, folders, and manifests inside of a single `structure` element.
+- For examples of `frontmatter` elements, see the [Style Guide](../style-guide/_index.md#front-matter).

--- a/website/documentation/contribute/documentation/adding-existing-documentation/_index.md
+++ b/website/documentation/contribute/documentation/adding-existing-documentation/_index.md
@@ -1,0 +1,123 @@
+---
+title: Adding Already Existing Documentation
+description: Adding external Github documentation via manifest changes
+---
+
+## Overview
+
+In order to add GitHub documentation to the website that is hosted outside of the main repository, you need to make changes to the central manifest. You can usually find it in the `<organization-name>/<repo-name>/.docforge/` folder, for example [`gardener/documentation/.docforge`](https://github.com/gardener/documentation/tree/master/.docforge).
+
+Sample codeblock:
+```yaml
+- dir: machine-controller-manager
+  structure:
+  - file: _index.md
+    properties:
+      frontmatter:
+        title: Machine Controller Manager
+        weight: 1
+        description: Declarative way of managing machines for Kubernetes cluster
+    source:  https://github.com/gardener/machine-controller-manager/blob/DEFAULT_BRANCH/README.md
+  - fileTree: https://github.com/gardener/machine-controller-manager/tree/DEFAULT_BRANCH/docs
+```
+
+This short code snippet adds a whole repository worth of content and contains examples of some of the most important elements:
+- `- dir: <dir-name>` - the name of the directory in the navigation path; must correspond to the folder name if it already exists in the main repo
+- `structure:` - required after using `dir`; shows that the following lines contain a file structure
+- `- file: _index.md` - creates an index file
+- `properties:` - allows for manual setting/overwriting of the various properties a file can have
+- `source: <link>` - where the content is located; in this case, a single file
+- `- fileTree: <link>` - where the content is located; in this case, a whole folder
+
+
+## Adding Existing Documentation
+
+You can use the following templates in order to add documentation to the website that exists in other GitHub repositories.
+
+{{% alert color="info"  title="Note" %}}
+Proper identation is incredibly important, as yaml relies on it for nesting!
+{{% /alert %}}
+
+### Adding a Single File
+
+You can add a single topic to the website by providing a link to it in the manifest. You can chain multiple topics that way.
+
+```yaml
+- dir: <dir-name>
+  structure:
+  - file: <file-name>
+    frontmatter:
+      title: <topic-name>
+      description: <topic-description>
+      weight: <weight>
+    source: https://github.com/<path>/<file>
+```
+
+<details>
+<summary>Example</summary>
+
+```yaml
+- dir: dashboard
+  structure:
+  - file: _index.md
+    frontmatter:
+      title: Dashboard
+      description: The web UI for managing your projects and clusters
+      weight: 3
+    source: https://github.com/gardener/dashboard/blob/master/README.md
+```
+</details>
+
+### Adding Multiple Files
+
+You can also add multiple topics to the website at once.
+
+{{% alert color="info"  title="Note" %}}
+If the content you want to add does not have an `_index.md` file in it, it won't show up as a single section on the website.
+{{% /alert %}}
+
+#### Through a Folder
+
+```yaml
+  - dir: <dir-name>
+    structure:
+    - fileTree: https://github.com/<path>/<folder>
+```
+
+<details>
+<summary>Example</summary>
+
+```yaml
+  - dir: development
+    structure:
+    - fileTree: https://github.com/gardener/gardener/tree/master/docs/development
+```
+</details>
+
+#### Through a Manifest File
+
+```yaml
+- dir: <dir-name>
+  structure:
+  - file: _index.md
+    frontmatter:
+      title: <topic-name>
+      description: <topic-description>
+      weight: <weight>
+  - manifest: https://github.com/<path>/manifest.yaml
+```
+
+<details>
+<summary>Example</summary>
+
+```yaml
+- dir: extensions
+  structure:
+  - file: _index.md
+    frontmatter:
+      title: List of Extensions
+      description: The infrastructure, networking, OS and other extension components for Gardener
+      weight: 2
+  - manifest: https://github.com/gardener/documentation/blob/master/.docforge/documentation/gardener-extensions/gardener-extensions.yaml
+```
+</details>

--- a/website/documentation/contribute/documentation/style-guide/_index.md
+++ b/website/documentation/contribute/documentation/style-guide/_index.md
@@ -59,21 +59,18 @@ There are a number of [predefined](https://gohugo.io/content-management/front-ma
 - `weight` a positive integer number that controls the ordering of the content in navigation structures.
 - `description` describes the content. For some content types such as documentation guides, it may be rendered in the UI.
 - `url` if specified, it will override the default url constructed from the file path to the content. Make sure the url you specify is consistent and meaningful. Prefer short paths. Do not provide redundant URLs!
-- `categories` specifies the type of user the topic is aimed towards. Currently only used in the public website.
+- `persona` specifies the type of user the topic is aimed towards. Use only a single persona per topic.
   ```
-  categories:
-  - Users
-  - Operators
-  - Developers
+  persona: Users / Operators / Developers
   ```
 
-While this section will be automatically generated if your topic has a title header, adding more detailed information helps other users, developers and technical writers better sort, classify and understand the topic. 
+While this section will be automatically generated if your topic has a title header, adding more detailed information helps other users, developers, and technical writers better sort, classify and understand the topic. 
 
 By using a metadata section you can also skip adding a title header or overwrite it in the navigation section. 
 
 ### Alerts
 
-If you want to add a note, tip, or a warning to your topic, use the templates provides in the [Shortcodes](../shortcodes/_index.md#alert) documentation.
+If you want to add a note, tip or a warning to your topic, use the templates provides in the [Shortcodes](../shortcodes/_index.md#alert) documentation.
 
 ### Images
 

--- a/website/documentation/contribute/documentation/style-guide/_index.md
+++ b/website/documentation/contribute/documentation/style-guide/_index.md
@@ -49,15 +49,15 @@ Sample codeblock:
 ```yaml
 ---
 title: Getting Started
-Description: Guides to get you accustomed with Gardener
-Weight: 10
+description: Guides to get you accustomed with Gardener
+weight: 10
 ---
 ```
 
 There are a number of [predefined](https://gohugo.io/content-management/front-matter#predefined) front matter properites, but not all of them are considered by the layouts developed for the website. The most essential ones to consider are:
 - `title` the content title that will be used as page title and in navigation structures.
-- `weight` a positive integer number that controls the ordering of the content in navigation structures.
 - `description` describes the content. For some content types such as documentation guides, it may be rendered in the UI.
+- `weight` a positive integer number that controls the ordering of the content in navigation structures.
 - `url` if specified, it will override the default url constructed from the file path to the content. Make sure the url you specify is consistent and meaningful. Prefer short paths. Do not provide redundant URLs!
 - `persona` specifies the type of user the topic is aimed towards. Use only a single persona per topic.
   ```


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds an "Adding Already Existing Documentation" topic to the Contributor's Guide and modifies certain other topics as well.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
Added "Adding Already Existing Documentation" topic to the Contributor's Guide
```
