### PR TITLE
gardenlogin should be used to transparently handle authentication

### DIFF
--- a/website/documentation/getting-started/shoots/_index.md
+++ b/website/documentation/getting-started/shoots/_index.md
@@ -84,7 +84,7 @@ The result of your provided inputs and a set of conscious default values is a sh
 
 Static credentials for shoots were discontinued in Gardener with Kubernetes v1.27. Short lived credentials need to be used instead. You can create/request tokens directly via Gardener or delegate authentication to an identity provider.
 
-A short-lived admin kubeconfig can be requested by using kubectl. If this is something you do frequently, consider switching to gardentctl (v2), which helps you with it.
+A short-lived admin kubeconfig can be requested by using kubectl. If this is something you do frequently, consider switching to [gardenlogin](https://github.com/gardener/gardenlogin), which helps you with it.
 
 ![](./images/access-shoot-2.png)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
gardenlogin should be used to handle authentication transparently.

gardenctl (v2) helps with switching between clusters and, in doing so, also generates the gardenlogin kubeconfig. However gardenlogin actually handles the shoot authentication.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
