### PR TITLE
use new code of conduct

### DIFF
--- a/website/documentation/contribute/_index.md
+++ b/website/documentation/contribute/_index.md
@@ -16,7 +16,7 @@ Before you begin contributing to Gardener, there are a couple of things you shou
 
 ### Code of Conduct
 All members of the Gardener community must abide by the
-[CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+[Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
 Only by respecting each other can we develop a productive, collaborative community.
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting [gardener.opensource@sap.com](mailto:gardener.opensource@sap.com) and/or a Gardener project maintainer.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Our guidelines recommend to use https://www.contributor-covenant.org/version/2/1/code_of_conduct/.
All our gardener repos already refer to this new code of conduct, so change it here makes sense to not have two different code of conduct versions