### PR TITLE
Fixed broken links - 2024.04-2: remove gardener-extension-provider-vsphere from public site

### DIFF
--- a/.docforge/documentation/gardener-extensions/infrastructure.yaml
+++ b/.docforge/documentation/gardener-extensions/infrastructure.yaml
@@ -65,14 +65,6 @@ structure:
       description: Gardener extension controller for the OpenStack cloud provider
     source:  https://github.com/gardener/gardener-extension-provider-openstack/blob/master/README.md
   - fileTree: https://github.com/gardener/gardener-extension-provider-openstack/tree/master/docs
-- dir: gardener-extension-provider-vsphere
-  structure:
-  - file: _index.md
-    frontmatter:
-      title: Provider vSphere
-      description: Gardener extension controller for the vSphere cloud provider
-    source:  https://github.com/gardener/gardener-extension-provider-vsphere/blob/main/README.md
-  - fileTree: https://github.com/gardener/gardener-extension-provider-vsphere/tree/main/docs
 - dir: gardener-extension-provider-equinix-metal
   structure:
   - file: _index.md


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes outdated content from the website.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
NONE
```
