### PR TITLE
Fix typos in docs

### DIFF
--- a/website/documentation/getting-started/architecture/_index.md
+++ b/website/documentation/getting-started/architecture/_index.md
@@ -27,7 +27,7 @@ In other terms: you use Kubernetes to run Kubernetes.
 
 Gardener uses many Kubernetes clusters to eventually provide you with your very own shoot cluster.
 
-At the heart of Gardener's cluster hierarchy is the garden cluster. Since Gardener is 100% Kubernetes native, a Kubernetes cluster is needed to store all Gardener related resources. The garden cluster is actually nodeless - it only consist of a control plane, an API server (actually two), an etcd, and a bunch of controllers. The garden cluster is the central brain of a Gardener landscape and the one you connect to in order to create, modify or delete shoot clusters - either with kubectl and a dedicated kubeconfig or though the Gardener dashboard.
+At the heart of Gardener's cluster hierarchy is the garden cluster. Since Gardener is 100% Kubernetes native, a Kubernetes cluster is needed to store all Gardener related resources. The garden cluster is actually nodeless - it only consists of a control plane, an API server (actually two), an etcd, and a bunch of controllers. The garden cluster is the central brain of a Gardener landscape and the one you connect to in order to create, modify or delete shoot clusters - either with kubectl and a dedicated kubeconfig or through the Gardener dashboard.
 
 The seed clusters are next in the hierarchy - they are the clusters which will host the "kubeceptioned" control planes of the shoot clusters. For every hyperscaler supported in a Gardener landscape, there would be at least one seed cluster. However, to reduce latencies as well as for scaling, Gardener landscapes have several different seeds in different regions across the globe to keep the distance between control planes and actual worker nodes small.
 

--- a/website/documentation/getting-started/introduction/_index.md
+++ b/website/documentation/getting-started/introduction/_index.md
@@ -55,7 +55,7 @@ Essentially, it was a "make or buy" decision that led to the founding of Gardene
 
 ### The Reason Why We Choose to "Make It"
 
-Gardener allows to run Kubernetes clusters on various hyperscalers. It offers the same set of basic configuration options independent of the choosen infrastructure. This kind of harmonization supports any multi-vendor strategy while reducing adoption costs for the individual teams. Just imagine having to deal with multiple vendors all offering vastly different Kubernetes clusters.
+Gardener allows to run Kubernetes clusters on various hyperscalers. It offers the same set of basic configuration options independent of the chosen infrastructure. This kind of harmonization supports any multi-vendor strategy while reducing adoption costs for the individual teams. Just imagine having to deal with multiple vendors all offering vastly different Kubernetes clusters.
 
 Of course, there are plenty more reasons - from acquiring operational knowledge to having influence on the developed features - that made the pendulum swing towards "make it".
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix typos in docs

**Which issue(s) this PR fixes**:
Fixes typos in `website/documentation/getting-started/architecture/_index.md` and `website/documentation/getting-started/introduction/_index.md`.
