### PR TITLE
Removed Architecture folder from manifest due to move

### DIFF
--- a/.docforge/documentation/documentation.yaml
+++ b/.docforge/documentation/documentation.yaml
@@ -99,13 +99,6 @@ structure:
         weight: 6
       source: https://github.com/gardener/dashboard/blob/master/README.md
     - fileTree: https://github.com/gardener/dashboard/tree/master/docs
-    - dir: architecture
-      structure:
-      - file: _index.md
-        frontmatter:
-          title: Architecture
-          weight: 1
-          persona: Developers
   - file: gardenctl-v2
     frontmatter:
       aliases:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes the code that explicitly added a folder for the Architecture topic, as [this PR in gardener/dashboard](https://github.com/gardener/dashboard/pull/1862) moves the topic to the `development` folder for better visibility.

The Architecture topic will now be added to the website together with all the other files in the `development` folder.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
NONE
```
