### PR TITLE
Moved Security Content

### DIFF
--- a/.docforge/documentation/documentation.yaml
+++ b/.docforge/documentation/documentation.yaml
@@ -13,9 +13,6 @@ structure:
     - manifest: ./guides.yaml
   - dir: security-and-compliance
     structure:
-    - file: _index.md
-      frontmatter:
-        weight: 3
     - manifest: ./security-and-compliance.yaml
   - dir: gardener
     structure:

--- a/.docforge/documentation/documentation.yaml
+++ b/.docforge/documentation/documentation.yaml
@@ -11,6 +11,9 @@ structure:
         persona: Developers
         weight: 2
     - manifest: ./guides.yaml
+  - dir: security-and-compliance
+    structure:
+    - manifest: ./security-and-compliance.yaml
   - dir: gardener
     structure:
     - file: _index.md

--- a/.docforge/documentation/documentation.yaml
+++ b/.docforge/documentation/documentation.yaml
@@ -13,6 +13,9 @@ structure:
     - manifest: ./guides.yaml
   - dir: security-and-compliance
     structure:
+    - file: _index.md
+      frontmatter:
+        weight: 3
     - manifest: ./security-and-compliance.yaml
   - dir: gardener
     structure:

--- a/.docforge/documentation/guides.yaml
+++ b/.docforge/documentation/guides.yaml
@@ -1,10 +1,5 @@
 structure:
 - fileTree: /website/documentation/guides
-- dir: security-and-compliance
-  structure:
-  - file: https://github.com/gardener/diki/blob/main/docs/usage/partial-disa-k8s-stig-shoot.md
-    frontmatter:
-      title: Run DISA K8s STIGs Ruleset
 - dir: high-availability
   structure:
   - file: _index.md

--- a/.docforge/documentation/security-and-compliance.yaml
+++ b/.docforge/documentation/security-and-compliance.yaml
@@ -3,6 +3,7 @@ structure:
   frontmatter:
     title: Security and Compliance
     description: Make sure that your clusters are compliant and secure
+    weight: 3
     aliases: ["/docs/guides/compliance/", "/docs/guides/security-and-compliance/"]
 - fileTree: /website/documentation/security-and-compliance
 - file: https://github.com/gardener/diki/blob/main/docs/usage/partial-disa-k8s-stig-shoot.md

--- a/.docforge/documentation/security-and-compliance.yaml
+++ b/.docforge/documentation/security-and-compliance.yaml
@@ -1,13 +1,11 @@
 structure:
-  - dir: security-and-compliance
-    structure:
-    - file: _index.md
-      frontmatter:
-        title: Security and Compliance
-        weight: 3
-        aliases: ["/docs/guides/compliance/", "/docs/guides/security-and-compliance/"]
-    - fileTree: /website/documentation/security-and-compliance
-    - file: https://github.com/gardener/diki/blob/main/docs/usage/partial-disa-k8s-stig-shoot.md
-      frontmatter:
-        title: Run DISA K8s STIGs Ruleset
-        aliases: ["/docs/guides/security-and-compliance/partial-disa-k8s-stig-shoot/"]
+- file: _index.md
+  frontmatter:
+    title: Security and Compliance
+    weight: 3
+    aliases: ["/docs/guides/compliance/", "/docs/guides/security-and-compliance/"]
+- fileTree: /website/documentation/security-and-compliance
+- file: https://github.com/gardener/diki/blob/main/docs/usage/partial-disa-k8s-stig-shoot.md
+  frontmatter:
+    title: Run DISA K8s STIGs Ruleset
+    aliases: ["/docs/guides/security-and-compliance/partial-disa-k8s-stig-shoot/"]

--- a/.docforge/documentation/security-and-compliance.yaml
+++ b/.docforge/documentation/security-and-compliance.yaml
@@ -2,7 +2,7 @@ structure:
 - file: _index.md
   frontmatter:
     title: Security and Compliance
-    weight: 3
+    description: Make sure that your clusters are compliant and secure
     aliases: ["/docs/guides/compliance/", "/docs/guides/security-and-compliance/"]
 - fileTree: /website/documentation/security-and-compliance
 - file: https://github.com/gardener/diki/blob/main/docs/usage/partial-disa-k8s-stig-shoot.md

--- a/.docforge/documentation/security-and-compliance.yaml
+++ b/.docforge/documentation/security-and-compliance.yaml
@@ -1,0 +1,13 @@
+structure:
+  - dir: security-and-compliance
+    structure:
+    - file: _index.md
+      frontmatter:
+        title: Security and Compliance
+        weight: 3
+        aliases: ["/docs/guides/compliance/", "/docs/guides/security-and-compliance/"]
+    - fileTree: /website/documentation/security-and-compliance
+    - file: https://github.com/gardener/diki/blob/main/docs/usage/partial-disa-k8s-stig-shoot.md
+      frontmatter:
+        title: Run DISA K8s STIGs Ruleset
+        aliases: ["/docs/guides/security-and-compliance/partial-disa-k8s-stig-shoot/"]

--- a/website/documentation/security-and-compliance/_index.md
+++ b/website/documentation/security-and-compliance/_index.md
@@ -3,5 +3,5 @@ title: Security and Compliance
 layout: guides-home
 aggregate: true
 weight: 20
-aliases: ["/docs/guides/compliance/"]
+aliases: ["/docs/guides/compliance/", "/docs/guides/security-and-compliance/"]
 ---

--- a/website/documentation/security-and-compliance/_index.md
+++ b/website/documentation/security-and-compliance/_index.md
@@ -1,7 +1,0 @@
----
-title: Security and Compliance
-layout: guides-home
-aggregate: true
-weight: 20
-aliases: ["/docs/guides/compliance/", "/docs/guides/security-and-compliance/"]
----

--- a/website/documentation/security-and-compliance/kubernetes-hardening/_index.md
+++ b/website/documentation/security-and-compliance/kubernetes-hardening/_index.md
@@ -5,7 +5,7 @@ level: advanced
 category: Security
 publishdate: 2023-10-10
 tags: ["task"]
-aliases: ["/docs/guides/kubernetes-hardening/"]
+aliases: ["/docs/guides/kubernetes-hardening/", "/docs/guides/security-and-compliance/kubernetes-hardening/"]
 ---
 
 ## Overview

--- a/website/documentation/security-and-compliance/regional-restrictions/_index.md
+++ b/website/documentation/security-and-compliance/regional-restrictions/_index.md
@@ -5,6 +5,7 @@ level: advanced
 category: Security
 publishdate: 2023-11-22
 tags: ["task"]
+aliases: ["/docs/guides/security-and-compliance/regional-restrictions/"]
 ---
 
 ## Shared Responsibility Model


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR moves the Security section to top level navigation in the public website
+ removed `_index.md` file, creating a file in the manifest instead
+ changed persona to Users
+ created new `security-and-compliance.yaml` manifest to host the content
+ added aliases to the moved files
+ removed section from the `guides.yaml` manifest
+ added description to the Security page

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
NONE
```
