### PR TITLE
Add usage aliases for previous structure

### DIFF
--- a/.docforge/documentation/documentation.yaml
+++ b/.docforge/documentation/documentation.yaml
@@ -76,6 +76,27 @@ structure:
       - fileTree: https://github.com/gardener/gardener/tree/master/docs/operations
     - dir: usage
       structure:
+      - dir: operating_through_annotations
+        frontmatter:
+          aliases: ["/docs/gardener"]
+      - dir: shoot_basics
+        frontmatter:
+          aliases: ["/docs/gardener"]
+      - dir: containerd
+        frontmatter:
+          aliases: ["/docs/gardener"]
+      - dir: shoot_updates_and_upgrades
+        frontmatter:
+          aliases: ["/docs/gardener"]
+      - dir: shoot_settings
+        frontmatter:
+          aliases: ["/docs/gardener"]
+      - dir: dns
+        frontmatter:
+          aliases: ["/docs/gardener"]
+      - dir: nessesary_considerations
+        frontmatter:
+          aliases: ["/docs/gardener"]
       - fileTree: https://github.com/gardener/gardener/tree/master/docs/usage
   - dir: extensions
     structure:


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/pull/9799

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
