### PR TITLE
Updated security.yaml due to diverging Kubernetes Hardening guides in the public and internal websites

### DIFF
--- a/.docforge/documentation/documentation.yaml
+++ b/.docforge/documentation/documentation.yaml
@@ -18,6 +18,8 @@ structure:
       multiSource:
       - /website/documentation/security-and-compliance/hardened-shoot-report/hardened_shoots_docu_report.md
       - /website/documentation/security-and-compliance/hardened-shoot-report/hardened_shoots_report.md   
+    - file: kubernetes-hardening
+      source: /website/documentation/security-and-compliance/kubernetes-hardening.md
   - dir: gardener
     structure:
     - file: _index.md

--- a/.docforge/documentation/security-and-compliance.yaml
+++ b/.docforge/documentation/security-and-compliance.yaml
@@ -9,6 +9,7 @@ structure:
   excludeFiles:
   - hardened-shoot-report/hardened_shoots_docu_report.md
   - hardened-shoot-report/hardened_shoots_report.md
+  - kubernetes-hardening.md
 - file: https://github.com/gardener/diki/blob/main/docs/usage/partial-disa-k8s-stig-shoot.md
   frontmatter:
     title: Run DISA K8s STIGs Ruleset


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the `security-and-compliance.yaml` due to diverging Kubernetes Hardening guides in the public and internal websites.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
NONE
```
