### PR TITLE
Removed duplicated guides - 2024.07

### DIFF
--- a/.docforge/documentation/documentation.yaml
+++ b/.docforge/documentation/documentation.yaml
@@ -83,6 +83,9 @@ structure:
     - dir: usage
       structure:
       - fileTree: https://github.com/gardener/gardener/tree/master/docs/usage
+        excludeFiles:
+        - shoot_high_availability_best_practices.md
+        - shoot_pod_autoscaling_best_practices.md
   - dir: extensions
     structure:
     - file: _index.md


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes duplicate guides from the documentation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
NONE
```
