### PR TITLE
Clarify two rules from Kubernetes Cluster Hardening Procedure

### DIFF
--- a/website/documentation/security-and-compliance/kubernetes-hardening.md
+++ b/website/documentation/security-and-compliance/kubernetes-hardening.md
@@ -27,8 +27,6 @@ The Gardener team takes security seriously, which is why we mandate the Security
 |245543|Kubernetes API Server must disable token authentication to protect information in transit|:white_check_mark:|Disabled unless you enable it via [enableStaticTokenKubeconfig](https://gardener.cloud/docs/gardener/api-reference/core/#kubernetes)|
 |242400|Kubernetes API server must have Alpha APIs disabled| :white_check_mark:| Disabled unless you enable it via [featureGates](https://gardener.cloud/docs/gardener/api-reference/core/#kubernetesconfig)|
 |242436|Kubernetes API server must have the ValidatingAdmissionWebhook enabled|:white_check_mark:|Enabled unless you disable it explicitly via [admissionPlugins](https://gardener.cloud/docs/gardener/api-reference/core/#kubeapiserverconfig)|
-|242398|Kubernetes DynamicAuditing must not be enabled|:white_check_mark:|Disabled unless you enable it via [featureGates](https://gardener.cloud/docs/gardener/api-reference/core/#kubernetesconfig)|
-|242399|Kubernetes DynamicKubeletConfig must not be enabled|:white_check_mark:|Disabled unless you enable it via [featureGates](https://gardener.cloud/docs/gardener/api-reference/core/#kubernetesconfig)|
 |242393|Kubernetes Worker Nodes must not have sshd service running| :x: | Active to allow debugging of network issues, but it is possible to deactivate via the [sshAccess](https://gardener.cloud/docs/gardener/api-reference/core/#core.gardener.cloud/v1beta1.SSHAccess) setting|
 |242394|Kubernetes Worker Nodes must not have the sshd service enabled| :x: | Enabled to allow debugging of network issues, but it is possible to deactivate via the [sshAccess](https://gardener.cloud/docs/gardener/api-reference/core/#core.gardener.cloud/v1beta1.SSHAccess) setting|
 |242434|Kubernetes Kubelet must enable kernel protection|:white_check_mark:|Enabled for Kubernetes v1.26 or later unless disabled explicitly via [protectKernalDefaults](https://gardener.cloud/docs/gardener/api-reference/core/#kubeletconfig)|
@@ -80,6 +78,8 @@ The Gardener team takes security seriously, which is why we mandate the Security
 |242392|The Kubernetes kubelet must enable explicit authorization.|
 |242396|Kubernetes Kubectl cp command must give expected access and results.|
 |242397|The Kubernetes kubelet staticPodPath must not enable static pods.|
+|242398|Kubernetes DynamicAuditing must not be enabled.|
+|242399|Kubernetes DynamicKubeletConfig must not be enabled.|
 |242404|Kubernetes Kubelet must deny hostname override.|
 |242405|The Kubernetes manifests must be owned by root.|
 |242406|The Kubernetes KubeletConfiguration file must be owned by root.|


### PR DESCRIPTION
**What this PR does / why we need it**:
These rules are not considered responsibility of the cluster admin because they were removed in 1.19 and 1.25 versions of Kubernetes. See https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates-removed/

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
