### PR TITLE
Updated the terms for phases in Credential Rotation topic

### DIFF
--- a/website/documentation/getting-started/features/credential-rotation.md
+++ b/website/documentation/getting-started/features/credential-rotation.md
@@ -19,13 +19,13 @@ kubectl -n <shoot-namespace> annotate shoot <shoot-name> gardener.cloud/operatio
 kubectl -n <shoot-namespace> annotate shoot <shoot-name> gardener.cloud/operation=rotate-credentials-complete​
 ```
 
-Where possible, the rotation happens in two phases. Phase 1 introduces new keys while the old ones are still valid. Users can safely exchange keys / CA bundles wherever they are used. Afterwards, phase 2 will invalidate the old keys / CA bundles.
+Where possible, the rotation happens in two phases - Preparing and Completing. The Preparing phase introduces new keys while the old ones are still valid. Users can safely exchange keys / CA bundles wherever they are used. Afterwards, the Completing phase will invalidate the old keys / CA bundles.
 
 ## Rotation Phases
 
 ![rotation-phases](./images/rotation-phases.png)
 
-At the beginning, only the old set of credentials exists. By triggering the rotation, new credentials are created in phase 1 and both sets are valid. Now, all clients have to update and start using the new credentials. Only afterwards it is safe to trigger phase 2, which invalidates the old credentials.
+At the beginning, only the old set of credentials exists. By triggering the rotation, new credentials are created in the Preparing phase and both sets are valid. Now, all clients have to update and start using the new credentials. Only afterwards it is safe to trigger the Completing phase, which invalidates the old credentials.
 
 The shoot's status will always show the current status / phase of the rotation.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the terms for phases in Credential Rotation topic - from `Phase 1` and `Phase 2` to the more descriptive `Preparing `and `Completing`.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/10484

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
NONE
```
