### PR TITLE
Added _index.md for the Resources folder

### DIFF
--- a/.docforge/documentation/documentation.yaml
+++ b/.docforge/documentation/documentation.yaml
@@ -59,6 +59,11 @@ structure:
           title: Extensions
           weight: 3
           persona: Developers
+      - dir: resources
+        structure:
+        - file: _index.md
+          frontmatter:
+            title: Resources
       - fileTree: https://github.com/gardener/gardener/tree/master/docs/extensions
     - dir: deployment
       structure:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds an index file to the newly created Resources folder in the Extensions directory of gardener/gardener.

Example (actual population of the new folder will be different):
![Screenshot 2024-10-10 164658](https://github.com/user-attachments/assets/f0773f02-52d0-486b-b97b-84905b6585c0)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Requires https://github.com/gardener/gardener/pull/10632 to be merged first.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
NONE
```
