### PR TITLE
Updated manifest to exclude included README files

### DIFF
--- a/.docforge/documentation/documentation.yaml
+++ b/.docforge/documentation/documentation.yaml
@@ -32,9 +32,6 @@ structure:
       source: https://github.com/gardener/gardener/blob/master/docs/README.md
     - dir: api-reference
       structure:
-      - fileTree: https://github.com/gardener/gardener/tree/master/docs/api-reference
-        excludeFiles:
-        - "README.md"
       - file: _index.md
         frontmatter:
           title: API Reference
@@ -43,6 +40,9 @@ structure:
           - "/api-reference/"
           persona: Developers
         source: https://github.com/gardener/gardener/blob/master/docs/api-reference/README.md
+      - fileTree: https://github.com/gardener/gardener/tree/master/docs/api-reference
+        excludeFiles:
+        - "README.md"
     - dir: concepts
       structure:
       - file: _index.md
@@ -78,7 +78,10 @@ structure:
           title: Monitoring
           weight: 5
           persona: Operators
+        source: https://github.com/gardener/gardener/tree/master/docs/monitoring/README.md
       - fileTree: https://github.com/gardener/gardener/tree/master/docs/monitoring
+        excludeFiles:
+        - "README.md"
     - dir: operations
       structure:
       - fileTree: https://github.com/gardener/gardener/tree/master/docs/operations
@@ -182,6 +185,8 @@ structure:
         weight: 6
       source: https://github.com/gardener/dashboard/blob/master/README.md
     - fileTree: https://github.com/gardener/dashboard/tree/master/docs
+      excludeFiles:
+      - "README.md"
   - file: gardenctl-v2
     frontmatter:
       aliases:

--- a/.docforge/documentation/other-components.yaml
+++ b/.docforge/documentation/other-components.yaml
@@ -9,7 +9,7 @@ structure:
     source:  https://github.com/gardener/machine-controller-manager/blob/master/README.md
   - fileTree: https://github.com/gardener/machine-controller-manager/tree/master/docs
     excludeFiles:
-    - FAQ.md
+    - "FAQ.md"
   - dir: documents
     structure:
     - file: _index.md
@@ -52,6 +52,8 @@ structure:
       persona: Developers
     source: https://github.com/gardener/etcd-druid-api/blob/main/docs/api-reference/druid.md
   - fileTree: https://github.com/gardener/etcd-druid/tree/master/docs
+    excludeFiles:
+    - "README.md"
 - dir: dependency-watchdog
   structure:
   - file: _index.md
@@ -61,6 +63,8 @@ structure:
       description: A watchdog which actively looks out for disruption and recovery of critical services
     source: https://github.com/gardener/dependency-watchdog/blob/master/README.md
   - fileTree: https://github.com/gardener/dependency-watchdog/tree/master/docs
+    excludeFiles:
+    - "README.md"
   - dir: concepts
     structure:
     - file: _index.md


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the manifests to have the `fileTree` additors ignore all README files already included, so as not to override the added frontmatter.

List of the files can be found in the [failed Concourse build](https://concourse.ci.gardener.cloud/builds/353280333), by going to the `e2e` section and searching for occurences of "Only in".
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
A fix for builds that will break once https://github.com/gardener/docforge/pull/349 gets merged.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
NONE
```
