### PR TITLE
docs: Fix reference to shoot operations documentation

### DIFF
--- a/website/documentation/faq/reconciliation-impact.md
+++ b/website/documentation/faq/reconciliation-impact.md
@@ -10,4 +10,4 @@ Infrastructure and DNSRecord reconciliation are only done during usual reconcili
 
 Reconciliation is bound to the maintenance time window of a cluster. This means that your shoot will be reconciled regularly, without need for input. 
 
-Outside of the maintenance time window your shoot will only reconcile if you change the specification or if you explicitly trigger it. To learn how, see [Trigger shoot operations](https://github.com/gardener/gardener/blob/master/docs/usage/shoot_operations.md).
+Outside of the maintenance time window your shoot will only reconcile if you change the specification or if you explicitly trigger it. To learn how, see [Trigger shoot operations](https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/shoot_operations.md).


### PR DESCRIPTION
**What this PR does / why we need it**:

The file has been moved with this PR: https://github.com/gardener/gardener/pull/10436
However, the reference here has not been updated accordingly therefore clicking the link leads to a 404 not found:
https://gardener.cloud/docs/faq/reconciliation-impact/#how-do-you-steer-a-reconciliation

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

_n.a._

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
Fixed a reference to the shoot operations documentation.
```
