### PR TITLE
Fixed "Analyzing Node Removal and Failures" file name

### DIFF
--- a/website/documentation/guides/monitoring-and-troubleshooting/analyzing-node-failures.md
+++ b/website/documentation/guides/monitoring-and-troubleshooting/analyzing-node-failures.md
@@ -3,6 +3,7 @@ title: Analyzing Node Removal and Failures
 description: "Utilize Gardener's Monitoring and Logging to analyze removal and failures of nodes"
 level: intermediate
 category: Debugging
+aliases: ["/docs/guides/monitoring-and-troubleshooting/analysing-node-failures/"]
 scope: operator
 ---
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the file name of "Analyzing Node Removal and Failures" from `analysing-node-failures` to `analyzing-node-failures` and adds an alias to the frontmatter.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
NONE
```
