### PR TITLE
Adapt documentation for removal of automatic `.md` addition in `Docforge`

### DIFF
--- a/.docforge/documentation/documentation.yaml
+++ b/.docforge/documentation/documentation.yaml
@@ -20,7 +20,7 @@ structure:
       multiSource:
       - /website/documentation/security-and-compliance/hardened-shoot-report/hardened_shoots_docu_report.md
       - /website/documentation/security-and-compliance/hardened-shoot-report/hardened_shoots_report.md   
-    - file: kubernetes-hardening
+    - file: kubernetes-hardening.md
       source: /website/documentation/security-and-compliance/kubernetes-hardening.md
   - dir: gardener
     structure:
@@ -192,7 +192,7 @@ structure:
     - fileTree: https://github.com/gardener/dashboard/tree/master/docs
       excludeFiles:
       - "README.md"
-  - file: gardenctl-v2
+  - file: gardenctl-v2.md
     frontmatter:
       aliases:
       - /docs/gardenctl/

--- a/.docforge/documentation/guides.yaml
+++ b/.docforge/documentation/guides.yaml
@@ -6,7 +6,7 @@ structure:
     frontmatter:
       title: High Availability
       weight: 20
-  - file: best-practices
+  - file: best-practices.md
     frontmatter:
       title: Best Practices
       level: advanced
@@ -15,7 +15,7 @@ structure:
       publishdate: 2023-03-17
       aliases: ["/readmore/shoot-high-availability-best-practices"]
     source: https://github.com/gardener/gardener/blob/master/docs/usage/high-availability/shoot_high_availability_best_practices.md
-  - file: control-plane
+  - file: control-plane.md
     frontmatter:
       title: Control Plane
       level: intermediate
@@ -24,7 +24,7 @@ structure:
       publishdate: 2023-03-17
       aliases: ["/readmore/shoot-high-availability-control-plane"]
     source: https://github.com/gardener/gardener/blob/master/docs/usage/high-availability/shoot_high_availability.md
-  - file: chaos-engineering
+  - file: chaos-engineering.md
     frontmatter:
       title: Chaos Engineering
       level: advanced
@@ -39,7 +39,7 @@ structure:
     frontmatter:
       title: Networking
       weight: 30
-  - file: DNS-extension
+  - file: DNS-extension.md
     frontmatter:
       title: Managing DNS with Gardener
       description: "Setup Gardener-managed DNS records in cluster."
@@ -50,7 +50,7 @@ structure:
       scope: operator
       aliases: ["/managing-dns-with-gardener", "/docs/015-guides/030-networking-lb/managed-dns"]
     source: https://github.com/gardener/gardener-extension-shoot-dns-service/blob/master/docs/usage/dns_names.md
-  - file: certificate-extension
+  - file: certificate-extension.md
     frontmatter:
       title: Manage Certificates with Gardener
       description: "Use the Gardener cert-management to get fully managed, publicly trusted TLS certificates"
@@ -61,7 +61,7 @@ structure:
       scope: operator
       aliases: ["/managing-certificates-with-gardener", "/docs/015-guides/030-networking-lb/managed-certs-from-lets-encrypt"]
     source: https://github.com/gardener/gardener-extension-shoot-cert-service/blob/master/docs/usage/request_cert.md
-  - file: certificate-extension-default-domain
+  - file: certificate-extension-default-domain.md
     frontmatter:
       title: Manage Certificates with Gardener for Default Domain
       description: "Use the Gardener cert-management to get fully managed, publicly trusted TLS certificates"
@@ -72,7 +72,7 @@ structure:
       scope: operator
       aliases: ["/managing-certificates-with-gardener-default-domain"]
     source: https://github.com/gardener/gardener-extension-shoot-cert-service/blob/master/docs/usage/request_default_domain_cert.md
-  - file: dual-stack-ipv4-ipv6-ingress-aws
+  - file: dual-stack-ipv4-ipv6-ingress-aws.md
     frontmatter:
       title: Enable IPv4/IPv6 (dual-stack) Ingress on AWS
       description: "Use IPv4/IPv6 (dual-stack) Ingress in an IPv4 single-stack cluster on AWS"
@@ -85,7 +85,7 @@ structure:
     source: https://github.com/gardener/gardener-extension-provider-aws/blob/master/docs/usage/dual-stack-ingress.md
 - dir: applications
   structure:
-  - file: shoot-pod-autoscaling-best-practices
+  - file: shoot-pod-autoscaling-best-practices.md
     frontmatter:
       title: Shoot Pod Autoscaling Best Practices
       level: advanced

--- a/.docforge/documentation/other-components.yaml
+++ b/.docforge/documentation/other-components.yaml
@@ -31,7 +31,7 @@ structure:
         title: ToDo
         weight: 4
         persona: Developers
-  - file: faq
+  - file: faq.md
     frontmatter:
       title: FAQ
       description: Frequently Asked Questions
@@ -45,7 +45,7 @@ structure:
       title: Etcd Druid
       description: A druid for etcd management in Gardener
     source: https://github.com/gardener/etcd-druid/blob/master/README.md
-  - file: api-reference
+  - file: api-reference.md
     frontmatter:
       title: API Reference
       weight: 1


### PR DESCRIPTION
**What this PR does / why we need it**:
With the introduction of support for multiple new valid file formats, the extension of the .md files becomes mandatory and will not be added automatically if the file name doesn't have it. Documentation is updated to follow the new logic.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/docforge/pull/352

**Special notes for your reviewer**:
/cc @Kostov6 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Extensions of .md files are now mandatory - otherwise the file won't be processed correctly by Docforge.
```
