### PR TITLE
Removed internal reuse of DISA STIGs Ruleset

### DIFF
--- a/.docforge/documentation/documentation.yaml
+++ b/.docforge/documentation/documentation.yaml
@@ -16,6 +16,11 @@ structure:
     - manifest: ./security-and-compliance.yaml
     - file: _index.md
       source: /website/documentation/security-and-compliance/_index.md
+    - file: https://github.com/gardener/diki/blob/main/docs/usage/disa-k8s-stig-shoot.md
+      frontmatter:
+        title: Run DISA K8s STIGs Ruleset
+        weight: 20
+        aliases: ["/docs/guides/security-and-compliance/partial-disa-k8s-stig-shoot/"]
     - file: report.md
       multiSource:
       - /website/documentation/security-and-compliance/hardened-shoot-report/hardened_shoots_docu_report.md

--- a/.docforge/documentation/security-and-compliance.yaml
+++ b/.docforge/documentation/security-and-compliance.yaml
@@ -5,11 +5,6 @@ structure:
   - hardened-shoot-report/hardened_shoots_docu_report.md
   - hardened-shoot-report/hardened_shoots_report.md
   - kubernetes-hardening.md
-- file: https://github.com/gardener/diki/blob/main/docs/usage/disa-k8s-stig-shoot.md
-  frontmatter:
-    title: Run DISA K8s STIGs Ruleset
-    weight: 20
-    aliases: ["/docs/guides/security-and-compliance/partial-disa-k8s-stig-shoot/"]
 - file: /website/documentation/getting-started/features/credential-rotation.md
   frontmatter:
     title: Credential Rotation


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes the internal reuse of the DISA STIGs Ruleset.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
NONE
```
