### PR TITLE
fix: Update to new `CloudProfile` reference

### DIFF
--- a/website/documentation/guides/administer-shoots/create-delete-shoot.md
+++ b/website/documentation/guides/administer-shoots/create-delete-shoot.md
@@ -29,7 +29,7 @@ In order to delete your cluster, you have to set an annotation confirming the de
 
 (the `hack` bash script can be found at [GitHub](https://github.com/gardener/gardener/blob/master/hack/usage/delete))
 
-## Configure a Shoot Cluster Aalert Receiver
+## Configure a Shoot Cluster Alert Receiver
 
 The receiver of the Shoot alerts can be configured from the `.spec.monitoring.alerting.emailReceivers` section in the Shoot specification. The value of the field has to be a list of valid mail addresses.
 

--- a/website/documentation/security-and-compliance/hardened-shoot-report/hardened_shoots_docu_report.md
+++ b/website/documentation/security-and-compliance/hardened-shoot-report/hardened_shoots_docu_report.md
@@ -27,7 +27,8 @@ apiVersion: core.gardener.cloud/v1beta1
 metadata:
   name: aws
 spec:
-  cloudProfileName: aws
+  cloudProfile:
+    name: aws
   kubernetes:
     kubeAPIServer:
       admissionPlugins:
@@ -103,7 +104,8 @@ apiVersion: core.gardener.cloud/v1beta1
 metadata:
   name: azure
 spec:
-  cloudProfileName: az
+  cloudProfile:
+    name: az
   kubernetes:
     kubeAPIServer:
       admissionPlugins:
@@ -176,7 +178,8 @@ apiVersion: core.gardener.cloud/v1beta1
 metadata:
   name: gcp
 spec:
-  cloudProfileName: gcp
+  cloudProfile:
+    name: gcp
   kubernetes:
     kubeAPIServer:
       admissionPlugins:
@@ -247,7 +250,8 @@ apiVersion: core.gardener.cloud/v1beta1
 metadata:
   name: openstack
 spec:
-  cloudProfileName: converged-cloud-cp
+  cloudProfile:
+    name: converged-cloud-cp
   kubernetes:
     kubeAPIServer:
       admissionPlugins:


### PR DESCRIPTION
**What this PR does / why we need it**:
Update from deprecated `cloudProfileName` to new `cloudProfile` reference in `Shoot` spec.

**Which issue(s) this PR fixes**:
See https://github.com/gardener/gardener/pull/10093.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
