### PR TITLE
Add Gardener Discovery Server to the public website

### DIFF
--- a/.docforge/documentation/other-components.yaml
+++ b/.docforge/documentation/other-components.yaml
@@ -35,3 +35,14 @@ structure:
   - fileTree: https://github.com/gardener/dependency-watchdog/tree/master/docs
     excludeFiles:
     - "README.md"
+- dir: gardener-discovery-server
+  structure:
+  - file: _index.md
+    frontmatter:
+      title: Gardener Discovery Server
+      weight: 1
+      description: A server which provides public metadata about different Gardener resources
+    source: https://github.com/gardener/gardener-discovery-server/blob/master/README.md
+  - fileTree: https://github.com/gardener/gardener-discovery-server/tree/master/docs
+    excludeFiles:
+    - "README.md"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the Gardener Discovery Server documentation to the Other Components section of the Gardener website.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
Added the Gardener Discovery Server documentation to the Other Components section of the Gardener website.
```
