### PR TITLE
Added Gardener Extensions Library topic

### DIFF
--- a/.docforge/documentation/documentation.yaml
+++ b/.docforge/documentation/documentation.yaml
@@ -70,6 +70,8 @@ structure:
           frontmatter:
             title: Resources
       - fileTree: https://github.com/gardener/gardener/tree/master/docs/extensions
+        excludeFiles:
+        - "overview.md"
     - dir: deployment
       structure:
       - file: _index.md
@@ -177,6 +179,7 @@ structure:
         title: List of Extensions
         description: The infrastructure, networking, OS and other extension components for Gardener
         weight: 4
+      source: https://github.com/gardener/gardener/blob/master/extensions/README.md
     - manifest: ./gardener-extensions/gardener-extensions.yaml
   - dir: other-components
     structure:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the Gardener Extensions Library topic to the List of Extensions section of the Gardener website.

![Screenshot 2025-03-17 144043](https://github.com/user-attachments/assets/8ab4a035-befa-4752-b598-2d86b1414dbc)

EDIT: The URL to the page will be https://gardener.cloud/docs/extensions/

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
Added the Gardener Extensions Library topic to the List of Extensions section
```
