### PR TITLE
Added ACL documentation and updated manifests - 2025.04

### DIFF
--- a/.docforge/documentation/documentation.yaml
+++ b/.docforge/documentation/documentation.yaml
@@ -9,7 +9,7 @@ structure:
         title: Guides
         description: Walkthroughs of common activities
         persona: Developers
-        weight: 2
+        weight: 20
     - manifest: ./guides.yaml
   - dir: security-and-compliance
     structure:
@@ -33,14 +33,14 @@ structure:
       frontmatter:
         title: Gardener
         description: The core component providing the extension API server of your Kubernetes cluster
-        weight: 3
+        weight: 30
       source: https://github.com/gardener/gardener/blob/master/docs/README.md
     - dir: api-reference
       structure:
       - file: _index.md
         frontmatter:
           title: API Reference
-          weight: 1
+          weight: 10
           aliases: 
           - "/api-reference/"
           persona: Developers
@@ -53,7 +53,7 @@ structure:
       - file: _index.md
         frontmatter:
           title: Concepts
-          weight: 2
+          weight: 20
           persona: Operators
       - fileTree: https://github.com/gardener/gardener/tree/master/docs/concepts
     - dir: extensions
@@ -62,7 +62,7 @@ structure:
         source: https://github.com/gardener/gardener/blob/master/docs/extensions/overview.md
         frontmatter:
           title: Extensions
-          weight: 3
+          weight: 30
           persona: Developers
       - dir: resources
         structure:
@@ -77,7 +77,7 @@ structure:
       - file: _index.md
         frontmatter:
           title: Deployment
-          weight: 4
+          weight: 40
           persona: Operators
       - fileTree: https://github.com/gardener/gardener/tree/master/docs/deployment
     - dir: development
@@ -88,7 +88,7 @@ structure:
       - file: _index.md
         frontmatter:
           title: Monitoring
-          weight: 5
+          weight: 50
           persona: Operators
         source: https://github.com/gardener/gardener/blob/master/docs/monitoring/README.md
       - fileTree: https://github.com/gardener/gardener/tree/master/docs/monitoring
@@ -106,7 +106,7 @@ structure:
         - file: _index.md
           frontmatter:
             title: Advanced
-            weight: 1
+            weight: 10
       - dir: autoscaling
         frontmatter:
           aliases: ["/docs/gardener"]
@@ -114,7 +114,7 @@ structure:
         - file: _index.md
           frontmatter:
             title: Autoscaling
-            weight: 2
+            weight: 20
       - dir: high-availability
         frontmatter:
           aliases: ["/docs/gardener"]
@@ -122,7 +122,7 @@ structure:
         - file: _index.md
           frontmatter:
             title: High Availability
-            weight: 3
+            weight: 30
       - dir: networking
         frontmatter:
           aliases: ["/docs/gardener"]
@@ -130,7 +130,7 @@ structure:
         - file: _index.md
           frontmatter:
             title: Networking
-            weight: 4
+            weight: 40
       - dir: observability
         frontmatter:
           aliases: ["/docs/gardener"]
@@ -138,7 +138,7 @@ structure:
         - file: _index.md
           frontmatter:
             title: Observability
-            weight: 5
+            weight: 50
       - dir: project
         frontmatter:
           aliases: ["/docs/gardener"]
@@ -146,7 +146,7 @@ structure:
         - file: _index.md
           frontmatter:
             title: Project
-            weight: 6
+            weight: 60
       - dir: security
         frontmatter:
           aliases: ["/docs/gardener"]
@@ -154,7 +154,7 @@ structure:
         - file: _index.md
           frontmatter:
             title: Security
-            weight: 7
+            weight: 70
       - dir: shoot
         frontmatter:
           aliases: ["/docs/gardener"]
@@ -162,7 +162,7 @@ structure:
         - file: _index.md
           frontmatter:
             title: Shoot
-            weight: 8
+            weight: 80
       - dir: shoot-operations
         frontmatter:
           aliases: ["/docs/gardener"]
@@ -170,7 +170,7 @@ structure:
         - file: _index.md
           frontmatter:
             title: Shoot Operations
-            weight: 9
+            weight: 90
       - fileTree: https://github.com/gardener/gardener/tree/master/docs/usage
   - dir: extensions
     structure:
@@ -178,7 +178,7 @@ structure:
       frontmatter:
         title: List of Extensions
         description: The infrastructure, networking, OS and other extension components for Gardener
-        weight: 4
+        weight: 40
       source: https://github.com/gardener/gardener/blob/master/extensions/README.md
     - manifest: ./gardener-extensions/gardener-extensions.yaml
   - dir: other-components
@@ -187,7 +187,7 @@ structure:
       frontmatter:
         title: Other Components
         description: Other components included in the Gardener project
-        weight: 5
+        weight: 50
     - manifest: ./other-components.yaml
   - dir: dashboard
     structure:
@@ -195,7 +195,7 @@ structure:
       frontmatter:
         title: Dashboard
         description: The web UI for managing your projects and clusters
-        weight: 6
+        weight: 60
       source: https://github.com/gardener/dashboard/blob/master/README.md
     - fileTree: https://github.com/gardener/dashboard/tree/master/docs
       excludeFiles:
@@ -206,7 +206,7 @@ structure:
       - /docs/gardenctl/
       title: Gardenctl V2
       description: The command line interface to control your clusters
-      weight: 7
+      weight: 70
     source: https://github.com/gardener/gardenctl-v2/blob/master/README.md
   - dir: faq
     structure:

--- a/.docforge/documentation/faq.yaml
+++ b/.docforge/documentation/faq.yaml
@@ -4,5 +4,5 @@ structure:
     title: FAQ
     description: Commonly asked questions about Gardener
     persona: Developers
-    weight: 8
+    weight: 80
 - fileTree: /website/documentation/faq

--- a/.docforge/documentation/gardener-extensions/gardener-extensions.yaml
+++ b/.docforge/documentation/gardener-extensions/gardener-extensions.yaml
@@ -1,11 +1,12 @@
 structure:
+- fileTree: /website/documentation/extensions
 - dir: infrastructure-extensions
   structure:
   - file: _index.md
     frontmatter:
       title: Infrastructure Extensions
       description: Gardener extension controllers for the different infrastructures
-      weight: 1
+      weight: 10
   - manifest: ./infrastructure.yaml
 - dir: os-extensions
   structure:
@@ -13,7 +14,7 @@ structure:
     frontmatter:
       title: Operating System Extensions
       description: Gardener extension controllers for the supported operating systems
-      weight: 2
+      weight: 20
   - manifest: ./operating-system.yaml
 - dir: network-extensions
   structure:
@@ -21,7 +22,7 @@ structure:
     frontmatter:
       title: Network Extensions
       description: Gardener extension controllers for the supported container network interfaces
-      weight: 3
+      weight: 30
   - manifest: ./network.yaml
 - dir: container-runtime-extensions
   structure:
@@ -29,13 +30,8 @@ structure:
     frontmatter:
       title: Container Runtime Extensions
       description: Gardener extensions for the supported container runtime interfaces
-      weight: 4
+      weight: 40
   - manifest: ./container-runtime.yaml
 - dir: others
   structure:
-  - file: _index.md
-    frontmatter:
-      title: Others
-      description: Other Gardener extensions
-      weight: 5
   - manifest: ./others.yaml

--- a/.docforge/documentation/gardener-extensions/others.yaml
+++ b/.docforge/documentation/gardener-extensions/others.yaml
@@ -3,7 +3,7 @@ structure:
   structure:
   - file: _index.md
     frontmatter:
-      title: DNS services
+      title: DNS Services
       description: Gardener extension controller for DNS services for shoot clusters
     source:  https://github.com/gardener/gardener-extension-shoot-dns-service/blob/master/README.md
   - fileTree: https://github.com/gardener/gardener-extension-shoot-dns-service/tree/master/docs
@@ -11,7 +11,7 @@ structure:
   structure:
   - file: _index.md
     frontmatter:
-      title: Certificate services
+      title: Certificate Services
       description: Gardener extension controller for certificate services for shoot clusters
     source:  https://github.com/gardener/gardener-extension-shoot-cert-service/blob/master/README.md
   - fileTree: https://github.com/gardener/gardener-extension-shoot-cert-service/tree/master/docs
@@ -19,7 +19,7 @@ structure:
   structure:
   - file: _index.md
     frontmatter:
-      title: OpenID Connect services
+      title: OpenID Connect Services
       description: Gardener extension controller for OpenID Connect services for shoot clusters
     source:  https://github.com/gardener/gardener-extension-shoot-oidc-service/blob/master/README.md
   - fileTree: https://github.com/gardener/gardener-extension-shoot-oidc-service/tree/master/docs
@@ -27,7 +27,7 @@ structure:
   structure:
   - file: _index.md
     frontmatter:
-      title: Egress filtering
+      title: Egress Filtering
       description: Gardener extension controller for egress filtering for shoot clusters
     source:  https://github.com/gardener/gardener-extension-shoot-networking-filter/blob/master/README.md
   - fileTree: https://github.com/gardener/gardener-extension-shoot-networking-filter/tree/master/docs
@@ -35,7 +35,7 @@ structure:
   structure:
   - file: _index.md
     frontmatter:
-      title: Networking problemdetector
+      title: Networking Problem Detector
       description: Gardener extension for deploying network problem detector
     source: https://github.com/gardener/gardener-extension-shoot-networking-problemdetector/blob/main/README.md
   - fileTree: https://github.com/gardener/gardener-extension-shoot-networking-problemdetector/tree/main/docs
@@ -43,7 +43,7 @@ structure:
   structure:
   - file: _index.md
     frontmatter:
-      title: Lakom service
+      title: Lakom Service
       description: A k8s admission controller verifying pods are using signed images (cosign signatures) and a gardener extension to install it for shoots and seeds.
     source: https://github.com/gardener/gardener-extension-shoot-lakom-service/blob/main/README.md
   - fileTree: https://github.com/gardener/gardener-extension-shoot-lakom-service/tree/main/docs
@@ -51,7 +51,7 @@ structure:
   structure:
   - file: _index.md
     frontmatter:
-      title: Registry cache
+      title: Registry Cache
       description: Gardener extension controller which deploys pull-through caches for container registries.
     source: https://github.com/gardener/gardener-extension-registry-cache/blob/main/README.md
   - fileTree: https://github.com/gardener/gardener-extension-registry-cache/tree/main/docs

--- a/.docforge/documentation/other-components.yaml
+++ b/.docforge/documentation/other-components.yaml
@@ -4,7 +4,6 @@ structure:
   - file: _index.md
     frontmatter:
       title: Machine Controller Manager
-      weight: 1
       description: Declarative way of managing machines for Kubernetes cluster
     source:  https://github.com/gardener/machine-controller-manager/blob/master/README.md
   - fileTree: https://github.com/gardener/machine-controller-manager/tree/master/docs
@@ -18,7 +17,6 @@ structure:
   - file: api-reference.md
     frontmatter:
       title: API Reference
-      weight: 1
       persona: Developers
     source: https://github.com/gardener/etcd-druid-api/blob/main/docs/api-reference/druid.md
   - fileTree: https://github.com/gardener/etcd-druid/tree/master/docs
@@ -29,7 +27,6 @@ structure:
   - file: _index.md
     frontmatter:
       title: Dependency Watchdog
-      weight: 1
       description: A watchdog which actively looks out for disruption and recovery of critical services
     source: https://github.com/gardener/dependency-watchdog/blob/master/README.md
   - fileTree: https://github.com/gardener/dependency-watchdog/tree/master/docs
@@ -40,7 +37,6 @@ structure:
   - file: _index.md
     frontmatter:
       title: Gardener Discovery Server
-      weight: 1
       description: A server which provides public metadata for Gardener resources
     source: https://github.com/gardener/gardener-discovery-server/blob/main/README.md
   - fileTree: https://github.com/gardener/gardener-discovery-server/tree/main/docs
@@ -51,7 +47,6 @@ structure:
   - file: _index.md
     frontmatter:
       title: Network Problem Detector
-      weight: 1
       description: A tool which diagnoses network issues in Kubernetes clusters by performing various connectivity checks
     source: https://github.com/gardener/network-problem-detector/blob/main/README.md
   - fileTree: https://github.com/gardener/network-problem-detector/tree/main/docs

--- a/website/community/review-meetings/2025-reviews.md
+++ b/website/community/review-meetings/2025-reviews.md
@@ -5,7 +5,7 @@ weight: -2025
 
 ## Overview
 
-In case you couldn't participate and are interested in catching up, you can find the contents of the review meetings we have had in 2024 here.
+In case you couldn't participate and are interested in catching up, you can find the contents of the review meetings we have had in 2025 here.
 
 Check back regularly for updates and upcoming topics!
 

--- a/website/documentation/contribute/_index.md
+++ b/website/documentation/contribute/_index.md
@@ -4,7 +4,7 @@ description: Contributors guides for code and documentation
 sidebar: true
 menu: sln
 persona: Developers
-weight: 11
+weight: 110
 ---
 
 # Contributing to Gardener

--- a/website/documentation/extensions/others/_index.md
+++ b/website/documentation/extensions/others/_index.md
@@ -1,0 +1,5 @@
+---
+title: Others
+description: Other Gardener extensions
+weight: 50
+---

--- a/website/documentation/extensions/others/acl-extension.md
+++ b/website/documentation/extensions/others/acl-extension.md
@@ -13,6 +13,6 @@ This extension supports multiple ingress namespaces, enhancing its flexibility f
 The extension's functionality and limitations are intricately managed to handle different access types effectively, ensuring robust security for Kubernetes API servers.
 
 > [!NOTE]
-> The ACL extension is not part of Gardener and is maintained by a different company.
+> The ACL extension is not part of Gardener and is maintained by STACKIT in their own GitHub organization.
 
 You can find more information in the [Gardener ACL Extension](https://github.com/stackitcloud/gardener-extension-acl) repository.

--- a/website/documentation/extensions/others/acl-extension.md
+++ b/website/documentation/extensions/others/acl-extension.md
@@ -1,0 +1,18 @@
+---
+title: Access Control List Extension
+---
+
+# Gardener Access Control List Extension
+
+An Access Control List (ACL) is a list of permissions attached to an object, specifying which users or system processes are granted or denied access to that object.
+
+Gardener utilizes the ACL extension to control access to shoot clusters using an allow-list mechanism, allowing you to specify which IP addresses or CIDR blocks are allowed to access the Kubernetes API and other services in the shoot cluster.
+
+This extension supports multiple ingress namespaces, enhancing its flexibility for various deployment scenarios. The extension leverages Istio's envoy proxy to insert additional configuration that limits access to specific clusters, impacting different external traffic flows such as Kubernetes API listeners, service listeners, and VPN listeners.
+
+The extension's functionality and limitations are intricately managed to handle different access types effectively, ensuring robust security for Kubernetes API servers.
+
+> [!NOTE]
+> The ACL extension is not part of Gardener and is maintained by a different company.
+
+You can find more information in the [Gardener ACL Extension](https://github.com/stackitcloud/gardener-extension-acl) repository.

--- a/website/documentation/getting-started/_index.md
+++ b/website/documentation/getting-started/_index.md
@@ -2,7 +2,7 @@
 title: Getting Started
 description: Gardener onboarding materials
 persona: Users
-weight: 1
+weight: 10
 ---
 
 Welcome to the Gardener Getting Started section! Here you will be able to get accustomed to the way Gardener functions and learn how its components work together in order to seamlessly run Kubernetes clusters on various hyperscalers.

--- a/website/documentation/glossary/_index.md
+++ b/website/documentation/glossary/_index.md
@@ -2,7 +2,7 @@
 title: Glossary
 description: Commonly used terms in Gardener
 persona: Users
-weight: 9
+weight: 90
 ---
 ## Purpose
 

--- a/website/documentation/guides/administer-shoots/tailscale.md
+++ b/website/documentation/guides/administer-shoots/tailscale.md
@@ -8,7 +8,7 @@ The most common way to secure a Kubernetes cluster which was created with Garden
 
 However, those solutions are not without their drawbacks. Managing the ACL extension becomes fairly difficult with the growing number of participants, especially in a dynamic environment and work from home scenarios, and using ExposureClass requires you to first have a corporate network suitable for this purpose.
 
-But there is a solution which bridges the gap between these two approaches by the use of a mesh VPN based on [WireGuard](https://www.wireguard.com/)
+But there is a solution which bridges the gap between these two approaches by the use of a mesh VPN based on [WireGuard](https://www.wireguard.com/).
 
 ## Tailscale
 

--- a/website/documentation/resources/_index.md
+++ b/website/documentation/resources/_index.md
@@ -3,7 +3,7 @@ title: Resources
 description: Interesting and useful content on Kubernetes
 aliases: ["/docs/resources/resources"]
 persona: Developers
-weight: 10
+weight: 100
 ---
 
 ## Overview

--- a/website/documentation/security-and-compliance/_index.md
+++ b/website/documentation/security-and-compliance/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Security and Compliance
 description: Make sure that your clusters are compliant and secure
-weight: 3
+weight: 30
 aliases: ["/docs/security-and-compliance/"]
 ---


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR:
- adds the "Access Control List Extension" topic to the List of Extensions -> Others section
- updates the weights of the topics in the manifests
- updates the manifests
- adds a new _index.md to the "Others" section

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
Added "Access Control List Extension" topic to the List of Extensions -> Others section
```
