### PR TITLE
Add newline to `<code> `block in formatting guide for consistent formatting

### DIFF
--- a/website/documentation/contribute/documentation/formatting-guide.md
+++ b/website/documentation/contribute/documentation/formatting-guide.md
@@ -128,6 +128,7 @@ Another thing to keep in mind is that markdown links do not work in certain [sho
 ### Separate Commands from Output
 
 <code>
+
 Verify that the pod is running on your chosen node:
 
     kubectl get pods --output=wide

--- a/website/documentation/contribute/documentation/formatting-guide.md
+++ b/website/documentation/contribute/documentation/formatting-guide.md
@@ -23,7 +23,6 @@ These are guidelines, not rules. Use your best judgment, and feel free to propos
 | [Links and References](#links-and-references) | [link]() | `Visit the [Gardener website](https://gardener.cloud/)` |
 | [Headers](#headers) | various | `# API Server` |
 
-
 ### API Objects and Technical Components
 
 When you refer to an API object, use the same uppercase and lowercase letters
@@ -124,7 +123,6 @@ Another thing to keep in mind is that markdown links do not work in certain [sho
 |:---|:---|
 | `kubectl get pods`  | `$ kubectl get pods` |
 
-
 ### Separate Commands from Output
 
 <code>
@@ -147,9 +145,8 @@ represents, for example:
 <code>
 
 Display information about a pod:
-```
-kubectl describe pod <pod-name>
-```
+
+    kubectl describe pod <pod-name>
 
 `<pod-name>` is the name of one of your pods.
 
@@ -160,5 +157,6 @@ kubectl describe pod <pod-name>
 Make code examples and configuration examples that include version information consistent with the accompanying text. Identify the Kubernetes version in the **Prerequisites** section.
 
 ## Related Links
+
 * [Style Guide](./style-guide/_index.md)
 * [Contributors Guide](../_index.md)


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes `<code>` format consistent.

**Which issue(s) this PR fixes**:
mentioned in https://github.com/gardener/website-generator/issues/290

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
