### PR TITLE
Move pipeline definitions from gardener-website repo

### DIFF
--- a/.ci/404.sh
+++ b/.ci/404.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+pushd hugo/content || exit
+
+cat > ../static/js/404.js <<EOF
+links = [
+EOF
+
+find . -type f \
+    | grep -v "__resources" \
+    | sed -E 's|\.md$|/",|; s|_index/||; s|^\.|"https://gardener.cloud|; ' >> ../static/js/404.js
+
+cat >> ../static/js/404.js <<EOF
+]
+
+titles = [
+EOF
+
+find . -type f -exec grep -H '^title: ' {} \; | sed 's/.*title: //; s/"//g; s/^/"/; s/$/",/'   >> ../static/js/404.js
+
+cat >> ../static/js/404.js <<EOF
+]
+
+let ul = document.getElementById('links');
+
+const newLinks = links.map((element, index) => [element, titles[index]]
+).filter( el => {
+    let splitUrl = window.location.href.split("/");
+    return el[0].endsWith("/" + splitUrl[splitUrl.length - 2] + "/")
+}).map( el => {
+    let li = document.createElement('li');
+    let a = document.createElement('a')
+    a.textContent = el[1]
+    a.setAttribute("href",el[0])
+    li.setAttribute("style","margin-bottom: 10px;")
+    li.appendChild(a)
+    ul.appendChild(li);
+})
+
+if (newLinks.length > 0) {
+    document.getElementById('404-descr').innerHTML = "It seems to have been planted somewhere else. Try checking some of these spots:"
+    document.getElementById('404-redirect').innerHTML = 'You could also go back to our <a href="https://gardener.cloud/">home page</a> or use the search bar to find what you were looking for.'
+}
+
+EOF
+
+popd || exit

--- a/.ci/build
+++ b/.ci/build
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -eu
+echo "Running website build script"
+
+getGitHubToken() {
+  # Check if gardener-ci is available (in local setup)
+  command -v gardener-ci >/dev/null && gardenci="true" || gardenci=""
+  if [[ $gardenci == "true" ]]; then
+    # Get a (round-robin) random technical GitHub user credentials
+    technicalUser=$(gardener-ci config model_element --cfg-type github --cfg-name "${1}" --key credentials | sed -e "s/^GithubCredentials //" -e "s/'/\"/g")
+    if [[ -n "${technicalUser}" ]]; then
+      # get auth token and strip lead/trail quotes
+      authToken=$(jq -r '.authToken' <<<"$technicalUser")
+      echo "${authToken}"
+    fi
+  fi
+}
+
+websiteRepoPath=$(readlink -f ${GARDENER_WEBSITE_PATH})
+website="${websiteRepoPath}/docs"
+repoPath="$(readlink -f "$(dirname "${0}")/..")"
+pushd "$repoPath"
+# Moving hugo to repo for building
+mv /hugo .
+# Running docforge
+GITHUB_OAUTH_TOKEN=$(getGitHubToken github_com) \
+DOCFORGE_CONFIG=".docforge/config.yaml" \
+docforge
+# Building 404.js
+./.ci/404.sh
+# Running hugo
+pushd hugo 
+rm -rf "$website"
+hugo --minify --destination "$website"
+# Bypass Jekyll processing 
+echo '' > "${website}/.nojekyll"
+popd
+# Remove hugo build
+rm -rf hugo
+popd
+echo "Committing website changes"
+pushd "$websiteRepoPath"
+git add . -A
+git commit -m 'Automatic build triggered by last commit [skip ci]' || true

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -1,15 +1,44 @@
-documentation:
-  template: "default"
+gardener-website-generator:
   base_definition:
-    traits:
-      version:
-        preprocess: "inject-commit-hash"
-        inject_effective_version: true
-      component_descriptor: ~
+    repos:
+    - name: 'gardener_website'
+      path: 'gardener/website'
+      branch: 'master'
   jobs:
     release:
       traits:
+        version:
+          preprocess: "finalize"
         release:
           nextversion: "bump_minor"
-        version:
-          preprocess: 'finalize'
+        component_descriptor:
+          ocm_repository: "europe-docker.pkg.dev/gardener-project/releases"
+        publish:
+          oci-builder: docker-buildx
+          platforms:
+          - linux/amd64
+          - linux/arm64
+          dockerimages:
+            website-generator:
+              tag_as_latest: True
+              image: "europe-docker.pkg.dev/gardener-project/releases/gardener-website-generator"
+    head-update:
+      steps:
+        build:
+          image: 'europe-docker.pkg.dev/gardener-project/releases/gardener-website-generator:latest'
+          publish_to: ['gardener_website']
+          cache_paths: ['.docforge']
+          notifications_cfg: 'website_maintainers'
+      traits:
+        cronjob:
+          interval: '24h'
+        notifications:
+          website_maintainers:
+            on_error:
+              recipients:
+              - email_addresses:
+                - v.kostov@sap.com
+                - dimitar.kostadinov@sap.com
+                - jordan.jordanov@sap.com
+                - nikolay.boshnakov@sap.com
+                - rada.dimitrova@sap.com


### PR DESCRIPTION
**What this PR does / why we need it**:
Moves pipeline definitions from gardener-website repo in order to archive it.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
