### PR TITLE
Standardized the footer content

### DIFF
--- a/website/hugo/layouts/partials/footer.html
+++ b/website/hugo/layouts/partials/footer.html
@@ -1,23 +1,18 @@
 <footer class="footer row d-print-none">
   <div class="container-fluid footer-wrapper">
     <ul class="nav">
-      {{- with .Site.GetPage "section" "documentation/020_getting-started" -}}
-      <li><a href='{{ .Permalink }}'>{{.Title}}</a></li>
-      {{- end -}}
-      {{- with .Site.GetPage "section" "blog" -}}
-      <li><a href='{{ .Permalink }}'>{{.Title}}</a></li>
-      {{- end -}}
-      {{- with .Site.GetPage "section" "news" -}}
-      <li><a href='{{ .Permalink }}'>{{.Title}}</a></li>
-      {{- end -}}
-      {{- with .Site.GetPage "section" "community" -}}
-      <li><a href='{{ .Permalink }}'>{{.Title}}</a></li>
-      {{- end -}}
+      <li><a href='https://demo.gardener.cloud'>Demo</a></li>
       {{- with .Site.GetPage "section" "adopter" -}}
       <li><a href='{{ .Permalink }}'>{{.Title}}</a></li>
       {{- end -}}
       {{- with .Site.GetPage "section" "docs" -}}
       <li><a href='{{ (or .Params.remoteUrl .Params.redirectUrl .Permalink) | relURL }}'>Documentation</a></li>
+      {{- end -}}
+      {{- with .Site.GetPage "section" "blog" -}}
+      <li><a href='{{ .Permalink }}'>{{.Title}}</a></li>
+      {{- end -}}
+      {{- with .Site.GetPage "section" "community" -}}
+      <li><a href='{{ .Permalink }}'>{{.Title}}</a></li>
       {{- end -}}
     </ul>
     <img src='{{"images/lp/gardener-logo.svg" | relURL}}' alt="Logo Gardener" class="logo" />


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the footer of the public Gardener website to have the same tabs and order as the header.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
NONE
```
