### PR TITLE
Update Docsy to v0.12.0 and Hugo to 0.147.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM europe-docker.pkg.dev/gardener-project/releases/3rd/alpine:3.20.1 as base
 
 RUN apk add curl
 
-ARG HUGO_VERSION=0.138.0
+ARG HUGO_VERSION=0.147.7
 ARG HUGO_TYPE=_extended
 ARG ARCH=_Linux-64bit
 ARG HUGO_ID=hugo${HUGO_TYPE}_${HUGO_VERSION}
@@ -16,7 +16,7 @@ RUN curl -fsSLO --compressed https://github.com/gohugoio/hugo/releases/download/
 FROM europe-docker.pkg.dev/gardener-project/releases/docforge:v0.55.0 as docforge
 FROM europe-docker.pkg.dev/gardener-project/releases/cicd/job-image:latest
 
-ARG DOCSY_VERSION=v0.11.0
+ARG DOCSY_VERSION=v0.12.0
 
 COPY --from=docforge /docforge /usr/local/bin/docforge
 COPY --from=base /usr/local/bin/hugo /usr/local/bin/hugo

--- a/website/hugo/layouts/_default/_markup/render-heading.html
+++ b/website/hugo/layouts/_default/_markup/render-heading.html
@@ -1,1 +1,0 @@
-{{ template "_default/_markup/td-render-heading.html" . }}

--- a/website/hugo/layouts/_markup/render-heading.html
+++ b/website/hugo/layouts/_markup/render-heading.html
@@ -1,0 +1,1 @@
+{{ partial "td/render-heading.html" . }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates Docsy version to v0.12.0 and Hugo version to 0.147.7 for maintenance of the newest available versions.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
/cc @n-boshnakov

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
