### PR TITLE
docs: update missing metadata to improve search results

### DIFF
--- a/website/documentation/contribute/code/cicd.md
+++ b/website/documentation/contribute/code/cicd.md
@@ -1,5 +1,9 @@
 ---
 title: CI/CD
+description: "Overview of Gardener's CI/CD infrastructure using Concourse as the execution environment, featuring a Pipeline Definition Contract for component build pipeline declarations, container-native workloads, and automated continuous delivery services for the Gardener project ecosystem."
+tags: [ci-cd, concourse, pipeline, continuous-delivery, container, automation, build, gardener, self-service, standardization]
+page_synonyms: [continuous-integration, continuous-deployment, build-pipeline, devops, pipeline-definition]
+categories: [development, infrastructure, automation, devops]
 ---
 
 ## CI/CD

--- a/website/documentation/contribute/code/contributing-bigger-changes.md
+++ b/website/documentation/contribute/code/contributing-bigger-changes.md
@@ -3,6 +3,10 @@ title: Contributing Bigger Changes
 sidebar: true
 menu: sln
 weight: 60
+description: "This page provides guidelines for contributing significant changes to the Gardener project, including the use of Gardener Enhancement Proposals (GEPs), breaking large changes into smaller pull requests, and collaborating effectively with reviewers to streamline the review process."
+categories: [contribution guidelines, development process]
+tags: [gardener, contribution, gep, pull request, review process, code contribution]
+page_synonyms: [large contributions, submitting big changes, gardener code contribution process]
 ---
 
 ## Contributing Bigger Changes

--- a/website/documentation/contribute/code/dependencies.md
+++ b/website/documentation/contribute/code/dependencies.md
@@ -1,6 +1,10 @@
 ---
 title: Dependencies
 remote: https://github.com/gardener/gardener/blob/master/docs/development/testing_and_dependencies.md
+description: "This page explains how to manage and update dependencies in the Gardener project, covering testing practices, the use of Go modules, integration with tools like Ginkgo and Gomega, and best practices for maintaining and updating the vendor directory."
+categories: [development process, dependency management, testing]
+tags: [dependencies, go modules, testing, ginkgo, gomega, vendor, makefile]
+page_synonyms: [managing dependencies, updating dependencies, gardener dependency guide]
 ---
 ## Testing
 

--- a/website/documentation/contribute/documentation/adding-existing-documentation.md
+++ b/website/documentation/contribute/documentation/adding-existing-documentation.md
@@ -1,5 +1,9 @@
 ---
 title: Adding Already Existing Documentation
+description: "This page details how to add existing documentation from external GitHub repositories to the Gardener website by editing manifest files, providing templates and examples for linking files, folders, and manifests, and offering tips for proper structure and integration."
+categories: [documentation contribution, content integration]
+tags: [documentation, manifest, github, integration, content structure, docforge]
+page_synonyms: [add external docs, integrate existing documentation, documentation manifest guide]
 ---
 
 ## Overview

--- a/website/documentation/contribute/documentation/formatting-guide.md
+++ b/website/documentation/contribute/documentation/formatting-guide.md
@@ -1,5 +1,9 @@
 ---
 title: Formatting Guide
+description: "This page outlines formatting guidelines for writing Gardener documentation, including best practices for inline elements, code snippets, headers, links, and versioning, to ensure consistency and clarity across all documentation topics."
+categories: [documentation guidelines, formatting]
+tags: [formatting, documentation, style, markdown, code snippets, headers, links]
+page_synonyms: [formatting rules, documentation formatting, gardener formatting guide]
 ---
 
 This page gives writing formatting guidelines for the Gardener documentation. For style guidelines, see the [Style Guide](./style-guide/_index.md).

--- a/website/documentation/contribute/documentation/images.md
+++ b/website/documentation/contribute/documentation/images.md
@@ -2,6 +2,10 @@
 title: Working with Images
 aliases: ["/docs/guides/contributors/content/images"]
 weight: 15
+description: "This page provides best practices for using images in Gardener documentation, covering image production, optimization, responsive design, recommended tools, and guidelines for including images and diagrams in markdown content."
+categories: [documentation guidelines, media usage]
+tags: [images, media, svg, png, optimization, responsive images, diagrams]
+page_synonyms: [image guidelines, using images in docs, gardener image best practices]
 ---
 
 Using images on the website has to contribute to the aesthetics and comprehensibility of the materials, with uncompromised experience when loading and browsing pages. That concerns crisp clear images, their consistent layout and color scheme, dimensions and aspect ratios, flicker-free and fast loading or the feeling of it, even on unreliable mobile networks and devices.

--- a/website/documentation/contribute/documentation/markup.md
+++ b/website/documentation/contribute/documentation/markup.md
@@ -1,5 +1,9 @@
 ---
 title: Markdown
+description: "This page explains the use of Markdown and HTML in Gardener documentation, advising on when to use each, the limitations of Markdown, and recommending alternatives like shortcodes for enhanced content formatting."
+categories: [documentation guidelines, content formatting]
+tags: [markdown, html, shortcodes, formatting, content authoring]
+page_synonyms: [markdown usage, html in docs, gardener markup guide]
 ---
 
 Hugo uses [Markdown](https://www.markdownguide.org/) for its simple content format. However, there are a lot of things that Markdown 

--- a/website/documentation/contribute/documentation/organization.md
+++ b/website/documentation/contribute/documentation/organization.md
@@ -1,5 +1,9 @@
 ---
 title: Organization
+description: "This page describes the organizational principles of Gardener documentation, emphasizing the documentation-as-code approach, repository structure, content organization by user roles, and the publishing process using docforge manifests."
+categories: [documentation guidelines, content organization]
+tags: [organization, documentation-as-code, repository structure, docforge, publishing]
+page_synonyms: [documentation structure, organizing docs, gardener documentation organization]
 ---
 
 The Gardener project implements the *documentation-as-code* paradigm. Essentially this means that:

--- a/website/documentation/contribute/documentation/pr-description.md
+++ b/website/documentation/contribute/documentation/pr-description.md
@@ -1,5 +1,9 @@
 ---
 title: Pull Request Description
+description: "This page provides a template and best practices for writing effective pull request descriptions and release notes in the Gardener project, helping contributors communicate changes clearly to reviewers and maintainers."
+categories: [contribution guidelines, pull requests]
+tags: [pull request, pr description, release notes, template, contribution]
+page_synonyms: [pr template, writing pull requests, gardener pr guide]
 ---
 
 <!-- contains only public information -->

--- a/website/documentation/contribute/documentation/shortcodes.md
+++ b/website/documentation/contribute/documentation/shortcodes.md
@@ -1,5 +1,9 @@
 ---
 title: Shortcodes
+description: "This page introduces the use of Hugo shortcodes in Gardener documentation, listing available built-in and custom shortcodes, and providing examples for extending Markdown functionality, such as alerts and mermaid diagrams."
+categories: [documentation guidelines, content enhancement]
+tags: [shortcodes, hugo, markdown, content enhancement, mermaid, alerts]
+page_synonyms: [shortcode reference, using shortcodes, gardener shortcode guide]
 ---
 
 Shortcodes are the Hugo way to extend the limitations of Markdown before resorting to HTML. There are a number of built-in shortcodes available from Hugo. This list is extended with Gardener website shortcodes designed specifically for its content.

--- a/website/documentation/contribute/documentation/style-guide/concept_template.md
+++ b/website/documentation/contribute/documentation/style-guide/concept_template.md
@@ -1,6 +1,10 @@
 ---
 Title: Concept Topic Structure
 Description: Describes the contents of a concept topic
+description: "This page presents a template for structuring concept topics in Gardener documentation, outlining recommended sections such as overview, main content headings, subheadings, and related links to ensure clarity and consistency."
+categories: [documentation guidelines, templates]
+tags: [style guide, template, concept topic, documentation structure]
+page_synonyms: [concept template, topic structure, gardener concept guide]
 ---
 
 # Concept Title

--- a/website/documentation/contribute/documentation/style-guide/reference_template.md
+++ b/website/documentation/contribute/documentation/style-guide/reference_template.md
@@ -1,6 +1,9 @@
 ---
-Title: Reference Topic Structure
-Description: Describes the contents of a reference topic
+title: Reference Topic Structure
+description: Template and structure guide for creating reference documentation topics in Gardener documentation
+tags: [documentation, template, reference, style-guide, writing]
+page_synonyms: [reference template, documentation template, reference structure, reference format]
+categories: [documentation, style-guide, templates]
 ---
 
 # Topic Title

--- a/website/documentation/contribute/documentation/style-guide/task_template.md
+++ b/website/documentation/contribute/documentation/style-guide/task_template.md
@@ -1,6 +1,9 @@
 ---
-Title: Task Topic Structure
-Description: Describes the contents of a task topic
+title: Task Topic Structure
+description: Template and structure guide for creating task-oriented documentation topics in Gardener documentation
+tags: [documentation, template, task, style-guide, writing, procedures]
+page_synonyms: [task template, procedure template, how-to template, task structure]
+categories: [documentation, style-guide, templates]
 ---
 
 # Task Title

--- a/website/documentation/extensions/others/acl-extension.md
+++ b/website/documentation/extensions/others/acl-extension.md
@@ -1,5 +1,9 @@
 ---
 title: Access Control List Extension
+description: Overview of the Gardener Access Control List (ACL) extension for controlling access to shoot clusters using allow-list mechanisms
+tags: [extensions, acl, access-control, security, networking, istio, stackit]
+page_synonyms: [acl extension, access control extension, allow-list extension, network access control]
+categories: [extensions, security, networking]
 ---
 
 # Gardener Access Control List Extension

--- a/website/documentation/getting-started/architecture.md
+++ b/website/documentation/getting-started/architecture.md
@@ -1,6 +1,10 @@
 ---
 title: Architecture
 weight: 2
+description: Comprehensive overview of Gardener's architecture including Kubeception, cluster hierarchy, API endpoints, and core components
+tags: [architecture, kubeception, kubernetes, api-server, etcd, cluster-hierarchy, garden-cluster, seed-cluster]
+page_synonyms: [gardener architecture, kubeception, kubernetes on kubernetes, cluster hierarchy, api aggregation]
+categories: [getting-started, architecture, concepts]
 ---
 
 ## Kubeception

--- a/website/documentation/getting-started/ca-components.md
+++ b/website/documentation/getting-started/ca-components.md
@@ -1,6 +1,10 @@
 ---
 title: Control Plane Components
 weight: 5
+description: Detailed explanation of Kubernetes control plane components in Gardener including etcd, API server, controllers, and Gardener-specific components
+tags: [control-plane, etcd, api-server, kubernetes, components, mcm, grm, vpn, dns, networking]
+page_synonyms: [control plane, master components, kubernetes components, gardener components, seed components]
+categories: [getting-started, architecture, components]
 ---
 
 ## Overview

--- a/website/documentation/getting-started/common-pitfalls.md
+++ b/website/documentation/getting-started/common-pitfalls.md
@@ -1,6 +1,10 @@
 ---
 title: Common Pitfalls
 weight: 9
+description: Common mistakes and pitfalls to avoid when using Gardener and Kubernetes, including architecture, scalability, networking, and webhook issues
+tags: [pitfalls, troubleshooting, best-practices, scalability, webhooks, networking, security, maintenance]
+page_synonyms: [common mistakes, troubleshooting, best practices, avoid pitfalls, kubernetes pitfalls]
+categories: [getting-started, troubleshooting, best-practices]
 ---
 
 ## Architecture

--- a/website/documentation/getting-started/features/certificate-management.md
+++ b/website/documentation/getting-started/features/certificate-management.md
@@ -1,6 +1,10 @@
 ---
 title: Certificate Management
 weight: 5
+description: Learn how to manage TLS certificates in Gardener using cert-manager and ACME challenges for secure service consumption with trusted CA-signed certificates.
+tags: [certificates, tls, cert-manager, acme, let's encrypt, security, ssl]
+page_synonyms: [cert management, certificate automation, tls management, ssl certificates, acme certificates]
+categories: [security, networking, automation]
 ---
 
 ## Certificate Management

--- a/website/documentation/getting-started/features/cluster-autoscaler.md
+++ b/website/documentation/getting-started/features/cluster-autoscaler.md
@@ -1,6 +1,10 @@
 ---
 title: Cluster Autoscaler
 weight: 7
+description: Understand how Gardener's cluster autoscaler automatically adds and removes nodes based on pod scheduling needs and resource utilization thresholds.
+tags: [cluster autoscaler, scaling, nodes, worker pools, priority scaling, machine controller manager]
+page_synonyms: [node scaling, automatic scaling, cluster scaling, worker scaling, pod scheduling]
+categories: [scaling, automation, resource management]
 ---
 
 ## Obtaining Aditional Nodes

--- a/website/documentation/getting-started/features/credential-rotation.md
+++ b/website/documentation/getting-started/features/credential-rotation.md
@@ -1,6 +1,10 @@
 ---
 title: Credential Rotation
 weight: 3
+description: Learn how to rotate credentials in Gardener including ETCD keys, certificate authorities, service account tokens, and user-provided cloud provider credentials.
+tags: [credential rotation, security, certificates, keys, etcd, ca rotation, service accounts, ssh keys]
+page_synonyms: [key rotation, certificate rotation, security rotation, credential management, key management]
+categories: [security, maintenance, operations]
 ---
 
 ## Keys

--- a/website/documentation/getting-started/features/dns-management.md
+++ b/website/documentation/getting-started/features/dns-management.md
@@ -1,6 +1,10 @@
 ---
 title: External DNS Management
 weight: 4
+description: Discover how Gardener automates external DNS management for Kubernetes services and ingresses using multiple cloud DNS providers.
+tags: [dns, external dns, dns management, dns providers, route53, azure dns, google clouddns, cloudflare]
+page_synonyms: [dns automation, domain management, dns records, dns providers, external dns service]
+categories: [networking, automation, dns]
 ---
 
 ## External DNS Management

--- a/website/documentation/getting-started/features/hibernation.md
+++ b/website/documentation/getting-started/features/hibernation.md
@@ -1,6 +1,10 @@
 ---
 title: Hibernation
 weight: 1
+description: Learn how to use Gardener's hibernation feature to shut down cluster components and reduce costs for development and testing environments.
+tags: [hibernation, cost optimization, cluster shutdown, development clusters, testing clusters, resource management]
+page_synonyms: [cluster hibernation, cluster shutdown, sleep mode, cost saving, cluster pause]
+categories: [cost optimization, resource management, operations]
 ---
 
 ## Hibernation

--- a/website/documentation/getting-started/features/vpa.md
+++ b/website/documentation/getting-started/features/vpa.md
@@ -1,6 +1,10 @@
 ---
 title: Vertical Pod Autoscaler
 weight: 6
+description: Learn how to enable and use the Vertical Pod Autoscaler in Gardener to automatically adjust pod resource requests and limits based on usage patterns.
+tags: [vpa, vertical pod autoscaler, resource management, cpu scaling, memory scaling, pod resources]
+page_synonyms: [vertical scaling, pod autoscaling, resource autoscaling, vpa controller, resource optimization]
+categories: [scaling, resource management, automation]
 ---
 
 ## Vertical Pod Autoscaler

--- a/website/documentation/getting-started/features/workerless-shoots.md
+++ b/website/documentation/getting-started/features/workerless-shoots.md
@@ -1,6 +1,10 @@
 ---
 title: Workerless Shoots
 weight: 2
+description: Understand how to create workerless shoots in Gardener for control plane-only Kubernetes clusters without worker nodes for orchestration use cases.
+tags: [workerless shoots, control plane, kubernetes api, orchestration, etcd, kube-apiserver, no nodes]
+page_synonyms: [control plane only, nodeless clusters, api only clusters, workerless clusters, control plane service]
+categories: [cluster types, orchestration, control plane]
 ---
 
 ## Controlplane as a Service

--- a/website/documentation/getting-started/introduction.md
+++ b/website/documentation/getting-started/introduction.md
@@ -1,6 +1,10 @@
 ---
 title: Introduction to Gardener
 weight: 1
+description: Introduction to Gardener - a system for managing Kubernetes clusters at scale using the desired state pattern and universal Kubernetes approach
+tags: [introduction, gardener, kubernetes, containers, orchestration, cluster-management, cncf, open-source]
+page_synonyms: [gardener introduction, what is gardener, kubernetes management, cluster management, universal kubernetes]
+categories: [getting-started, introduction, overview]
 ---
 
 ## Problem Space

--- a/website/documentation/getting-started/lifecycle.md
+++ b/website/documentation/getting-started/lifecycle.md
@@ -1,6 +1,10 @@
 ---
 title: Shoot Lifecycle
 weight: 6
+description: Understanding shoot cluster lifecycle including reconciliation, maintenance windows, version updates, and the impact of changes on cluster operations
+tags: [lifecycle, reconciliation, maintenance, updates, kubernetes-versions, os-versions, shoot-clusters]
+page_synonyms: [cluster lifecycle, shoot reconciliation, maintenance window, cluster updates, version management]
+categories: [getting-started, lifecycle, operations]
 ---
 
 ## Reconciliation in Kubernetes and Gardener

--- a/website/documentation/getting-started/observability/alerts.md
+++ b/website/documentation/getting-started/observability/alerts.md
@@ -1,6 +1,10 @@
 ---
 title: Alerts
 weight: 2
+description: Learn how to configure email alerts for control plane components and set up custom alerting using Prometheus federation in Gardener.
+tags: [alerts, monitoring, prometheus, email notifications, alerting, federation, custom alerts]
+page_synonyms: [alerting, notifications, monitoring alerts, prometheus alerts, email alerts, custom monitoring]
+categories: [observability, monitoring, alerting]
 ---
 
 ## Overview

--- a/website/documentation/getting-started/observability/components.md
+++ b/website/documentation/getting-started/observability/components.md
@@ -1,6 +1,10 @@
 ---
 title: Components
 weight: 1
+description: Explore Gardener's observability stack including Prometheus for metrics, Vali for logging, and Plutono for dashboards with detailed data flow explanations.
+tags: [observability, prometheus, vali, plutono, monitoring, logging, dashboards, metrics, grafana, loki]
+page_synonyms: [monitoring components, observability stack, prometheus monitoring, vali logging, plutono dashboards, monitoring stack]
+categories: [observability, monitoring, logging]
 ---
 
 ## Core Components

--- a/website/documentation/getting-started/observability/shoot-status.md
+++ b/website/documentation/getting-started/observability/shoot-status.md
@@ -1,6 +1,10 @@
 ---
 title: Shoot Status
 weight: 3
+description: Learn how to monitor shoot cluster health using status conditions, constraints, last operations, and credential rotation status information.
+tags: [shoot status, cluster health, conditions, constraints, last operation, credential rotation, monitoring]
+page_synonyms: [cluster status, shoot health, cluster monitoring, status conditions, cluster state, health monitoring]
+categories: [observability, monitoring, cluster management]
 ---
 
 ## Overview

--- a/website/documentation/getting-started/project.md
+++ b/website/documentation/getting-started/project.md
@@ -1,6 +1,10 @@
 ---
 title: Gardener Projects
 weight: 3
+description: Understanding Gardener projects including user management, permissions, infrastructure secrets, SecretBindings, and service accounts
+tags: [projects, user-management, permissions, secrets, secretbindings, service-accounts, namespaces, quotas]
+page_synonyms: [gardener projects, project management, user roles, infrastructure secrets, project namespaces]
+categories: [getting-started, projects, user-management]
 ---
 
 ## Overview

--- a/website/documentation/getting-started/shoots.md
+++ b/website/documentation/getting-started/shoots.md
@@ -1,6 +1,10 @@
 ---
 title: Gardener Shoots
 weight: 4
+description: Complete guide to Gardener shoot clusters including configuration options, worker pools, networking, access methods, and cluster management
+tags: [shoots, clusters, configuration, worker-pools, networking, access, kubernetes-versions, infrastructure]
+page_synonyms: [shoot clusters, kubernetes clusters, cluster configuration, gardener clusters, shoot management]
+categories: [getting-started, shoots, cluster-management]
 ---
 
 ## Overview

--- a/website/documentation/guides/administer-shoots/backup-restore.md
+++ b/website/documentation/guides/administer-shoots/backup-restore.md
@@ -1,12 +1,15 @@
 ---
 title: Backup and Restore of Kubernetes Objects
-description: Details about backup and recovery of Kubernetes objects based on the open source tool [Velero](https://velero.io/).
+description: Comprehensive guide to backup and restore Kubernetes objects using Velero, including setup, configuration, and best practices for disaster recovery
 level: intermediate
 index: 500
 category: Operation
 scope: app-developer
 publishdate: 2020-01-01
 aliases: [ "/readmore/br" ]
+tags: [backup, restore, velero, disaster recovery, kubernetes objects, persistent volumes, aws s3, data protection]
+page_synonyms: [backup and recovery, velero backup, kubernetes backup, disaster recovery, data backup, object backup]
+categories: [operations, data management, disaster recovery, backup solutions]
 ---
 
 ![Don't worry ... have a backup](images/teaser.png)

--- a/website/documentation/guides/administer-shoots/conversion-webhook.md
+++ b/website/documentation/guides/administer-shoots/conversion-webhook.md
@@ -1,8 +1,12 @@
 ---
 title: Fix Problematic Conversion Webhooks
+description: Guide to identify and resolve problematic Custom Resource Definition conversion webhooks that can break VPN connections and garbage collection
 level: advanced
 category: Operation
 scope: users
+tags: [conversion webhook, crd, custom resource definition, vpn, garbage collection, kubernetes api, etcd migration]
+page_synonyms: [webhook conversion, crd conversion, custom resource conversion, api versioning, resource migration]
+categories: [troubleshooting, kubernetes api, custom resources, operations]
 ---
 
 ## Reasoning

--- a/website/documentation/guides/administer-shoots/create-delete-shoot.md
+++ b/website/documentation/guides/administer-shoots/create-delete-shoot.md
@@ -1,8 +1,12 @@
 ---
 title: Create / Delete a Shoot Cluster
+description: Step-by-step guide to create and delete Gardener shoot clusters, including kubeconfig management and alert configuration
 level: advanced
 category: Operation
 scope: operator
+tags: [shoot cluster, create cluster, delete cluster, kubeconfig, alerting, prometheus, cluster lifecycle]
+page_synonyms: [cluster creation, cluster deletion, shoot management, cluster provisioning, cluster teardown]
+categories: [cluster management, operations, lifecycle management]
 ---
 
 ## Create a Shoot Cluster

--- a/website/documentation/guides/administer-shoots/create-shoot-into-existing-aws-vpc.md
+++ b/website/documentation/guides/administer-shoots/create-shoot-into-existing-aws-vpc.md
@@ -1,8 +1,12 @@
 ---
 title: Create a Shoot Cluster Into an Existing AWS VPC
+description: Tutorial on creating Gardener shoot clusters in existing AWS VPCs, including VPC setup, DNS configuration, and internet gateway requirements
 level: intermediate
 category: Operation
 scope: app-developer
+tags: [aws vpc, existing vpc, shoot cluster, aws infrastructure, internet gateway, dns configuration, vpc setup]
+page_synonyms: [existing vpc deployment, aws vpc integration, vpc reuse, custom vpc, pre-existing vpc]
+categories: [aws, networking, infrastructure, cluster deployment]
 ---
 
 ## Overview

--- a/website/documentation/guides/administer-shoots/gpu.md
+++ b/website/documentation/guides/administer-shoots/gpu.md
@@ -1,10 +1,13 @@
 ---
 title: GPU Enabled Cluster
-description: Setting up a GPU Enabled Cluster for Deep Learning
+description: Complete guide to setting up GPU-enabled Kubernetes clusters for deep learning workloads, including NVIDIA driver installation and device plugin configuration
 layout: single-page
 level: intermediate
 category: Setup
 scope: app-developer
+tags: [gpu, nvidia, deep learning, machine learning, tensorflow, keras, device plugin, daemonset, gpu acceleration]
+page_synonyms: [gpu cluster, nvidia cluster, machine learning cluster, deep learning setup, gpu acceleration, cuda cluster]
+categories: [gpu computing, machine learning, deep learning, hardware acceleration]
 ---
 
 ## Disclaimer

--- a/website/documentation/guides/administer-shoots/maintain-shoot.md
+++ b/website/documentation/guides/administer-shoots/maintain-shoot.md
@@ -1,9 +1,12 @@
 ---
 title: Shoot Cluster Maintenance
-description: "Understanding and configuring Gardener's Day-2 operations for Shoot clusters."
+description: Comprehensive guide to Gardener's Day-2 operations including Kubernetes version updates, OS updates, maintenance windows, and auto-update configuration
 level: advanced
 category: Operation
 scope: operator
+tags: [maintenance, kubernetes updates, os updates, auto-update, maintenance window, version management, cloudprofile, patch updates]
+page_synonyms: [cluster maintenance, day-2 operations, version updates, automatic updates, maintenance scheduling, cluster upgrades]
+categories: [maintenance, operations, version management, cluster lifecycle]
 ---
 
 ## Overview

--- a/website/documentation/guides/administer-shoots/oidc-login.md
+++ b/website/documentation/guides/administer-shoots/oidc-login.md
@@ -1,11 +1,14 @@
 ---
 title:  Authenticating with an Identity Provider
-description: "Use OpenID Connect to authenticate users to access shoot clusters"
+description: Complete guide to configuring OpenID Connect (OIDC) authentication for Gardener shoot clusters using identity providers like Auth0
 level: advanced
 index: 40
 category: Security
 scope: operator
 publishdate: 2020-12-01
+tags: [oidc, openid connect, authentication, identity provider, auth0, kubectl, rbac, security, user management]
+page_synonyms: [oidc authentication, openid connect, identity provider integration, user authentication, sso, single sign-on]
+categories: [security, authentication, identity management, access control]
 ---
 
 ## Prerequisites

--- a/website/documentation/guides/administer-shoots/scalability.md
+++ b/website/documentation/guides/administer-shoots/scalability.md
@@ -1,11 +1,14 @@
 ---
 title:  Scalability of Gardener Managed Kubernetes Clusters
-description: "Know the boundary conditions when scaling your workloads"
+description: Comprehensive guide to understanding scalability limits and best practices for Gardener-managed Kubernetes clusters across multiple dimensions
 level: advanced
 index: 40
 category: Operations
 scope: Users
 publishdate: 2023-05-23
+tags: [scalability, performance, etcd, kube-apiserver, nodes, pods, cluster limits, monitoring, capacity planning]
+page_synonyms: [cluster scalability, kubernetes limits, performance tuning, capacity planning, cluster sizing, scale limits]
+categories: [scalability, performance, capacity planning, cluster management]
 ---
 
 Have you ever wondered how much more your Kubernetes cluster can scale before it breaks down?

--- a/website/documentation/guides/administer-shoots/tailscale.md
+++ b/website/documentation/guides/administer-shoots/tailscale.md
@@ -1,3 +1,14 @@
+---
+title: Access the Kubernetes apiserver from your tailnet
+description: Guide to securing Kubernetes cluster access using Tailscale mesh VPN as an alternative to ACL extensions and ExposureClass
+level: advanced
+category: Security
+scope: operator
+tags: [tailscale, vpn, mesh vpn, wireguard, kubernetes apiserver, security, network access, acl, exposureclass]
+page_synonyms: [tailscale vpn, mesh vpn access, wireguard vpn, secure cluster access, vpn networking, tailnet access]
+categories: [security, networking, vpn, access control]
+---
+
 # Access the Kubernetes apiserver from your tailnet
 
 ## Overview

--- a/website/documentation/guides/applications/access-pod-from-local.md
+++ b/website/documentation/guides/applications/access-pod-from-local.md
@@ -1,11 +1,15 @@
 ---
 title: Access a Port of a Pod Locally
+description: Learn how to access pod ports locally without external load balancers using kubectl port-forward and Kubernetes apiserver proxy methods for testing and troubleshooting.
 level: beginner
 reviewer: Tieyan Fu
 status: Reviewed
 last_reviewed: 30.05.2018
 category: Debugging
 scope: app-developer
+tags: [kubectl, port-forward, proxy, debugging, local-access, testing]
+page_synonyms: [pod access, local port forwarding, kubectl proxy, apiserver proxy, port mapping]
+categories: [debugging, networking, troubleshooting]
 ---
 
 ## Question

--- a/website/documentation/guides/applications/antipattern.md
+++ b/website/documentation/guides/applications/antipattern.md
@@ -1,11 +1,14 @@
 ---
 title: Kubernetes Antipatterns
-description: "Common antipatterns for Kubernetes and Docker"
+description: Common antipatterns for Kubernetes and Docker including running as root, storing data in containers, using latest tags, and other security and operational pitfalls to avoid.
 level: beginner
 reviewer: Tieyan Fu
 last_reviewed: 12.06.2018
 category: Getting Started
 scope: app-developer
+tags: [antipatterns, best-practices, security, docker, containers, root-user, latest-tag, passwords]
+page_synonyms: [bad practices, common mistakes, kubernetes pitfalls, docker antipatterns, security issues]
+categories: [best-practices, security, getting-started]
 ---
 
 ![antipattern](./images/howto-antipattern.png)

--- a/website/documentation/guides/applications/commit-secret-fail.md
+++ b/website/documentation/guides/applications/commit-secret-fail.md
@@ -1,9 +1,12 @@
 ---
 title: Remove Committed Secrets in Github 💀
-description: "Never ever commit a kubeconfig.yaml into github"
+description: Learn how to remove sensitive data like kubeconfig.yaml or SSH keys from Git repository history using git filter-branch and prevent accidental secret commits.
 level: intermediate
 category: Fails
 scope: app-developer
+tags: [git, secrets, security, filter-branch, kubeconfig, ssh-keys, github, repository-cleanup]
+page_synonyms: [remove secrets, git history cleanup, sensitive data removal, secret leak fix, git filter]
+categories: [security, git, fails]
 ---
 
 ## Overview

--- a/website/documentation/guides/applications/container-startup.md
+++ b/website/documentation/guides/applications/container-startup.md
@@ -1,9 +1,12 @@
 ---
 title: Orchestration of Container Startup
-description: "How to orchestrate a startup sequence of multiple containers"
+description: Learn how to orchestrate container startup sequences using Kubernetes InitContainers to ensure dependencies are ready before main application containers start.
 level: beginner
 category: Getting Started
 scope: app-developer
+tags: [initcontainers, startup-sequence, dependencies, orchestration, postgresql, webapp, container-lifecycle]
+page_synonyms: [container ordering, startup dependencies, init containers, pod initialization, service dependencies]
+categories: [getting-started, containers, orchestration]
 ---
 
 ## Disclaimer

--- a/website/documentation/guides/applications/content_trust.md
+++ b/website/documentation/guides/applications/content_trust.md
@@ -1,9 +1,12 @@
 ---
 title: Integrity and Immutability
-description: "Ensure that you always get the right image"
+description: Learn about Docker content trust, image integrity, and immutability using SHA256 digests to ensure deterministic deployments and protect against malicious image tampering.
 level: intermediate
 category: Docker Registry
 scope: app-developer
+tags: [docker, content-trust, sha256, digest, immutability, integrity, security, deterministic-ops, image-verification]
+page_synonyms: [image integrity, docker trust, sha256 digest, image verification, deterministic deployment, content verification]
+categories: [security, docker-registry, best-practices]
 ---
 
 ## Introduction

--- a/website/documentation/guides/applications/dockerfile-pitfall.md
+++ b/website/documentation/guides/applications/dockerfile-pitfall.md
@@ -1,11 +1,14 @@
 ---
 title: Dockerfile Pitfalls
-description: "Common Dockerfile pitfalls"
+description: Common Dockerfile pitfalls including using latest tags, improper apt-get usage, and creating large container images with solutions for better practices.
 level: beginner
 reviewer: Tieyan Fu
 last_reviewed: 22.06.2018
 category: Fails
 scope: app-developer
+tags: [dockerfile, pitfalls, latest-tag, apt-get, alpine, multi-stage-builds, container-size, sha256]
+page_synonyms: [dockerfile mistakes, docker best practices, container optimization, image size reduction, dockerfile antipatterns]
+categories: [fails, docker, best-practices]
 ---
 
 

--- a/website/documentation/guides/applications/dynamic-pvc.md
+++ b/website/documentation/guides/applications/dynamic-pvc.md
@@ -1,10 +1,13 @@
 ---
 title: Dynamic Volume Provisioning
-description: "Running a Postgres database on Kubernetes"
+description: Learn how to run a Postgres database on Kubernetes with dynamic volume provisioning using PersistentVolumeClaims and storage classes for persistent data storage.
 layout: single-page
 level: beginner
 category: Getting Started
 scope: app-developer
+tags: [pvc, persistent-volumes, storage-class, postgres, dynamic-provisioning, reclaim-policy, volume-mounting]
+page_synonyms: [persistent volume claims, storage provisioning, database storage, volume management, pv pvc, kubernetes storage]
+categories: [getting-started, storage, databases]
 ---
 
 ## Overview

--- a/website/documentation/guides/applications/image-pull-policy.md
+++ b/website/documentation/guides/applications/image-pull-policy.md
@@ -1,9 +1,12 @@
 ---
 title: Container Image Not Updating
-description: "Updating images in your cluster during development"
+description: Learn how to fix container image update issues during development by using unique tags and understanding Kubernetes image pull policies to avoid cached image problems.
 level: intermediate
 category: Fails
 scope: app-developer
+tags: [image-pull-policy, docker-tags, ifnotpresent, versioning, deployment-updates, image-caching, unique-tags]
+page_synonyms: [image not updating, pull policy, docker cache, image versioning, deployment refresh, container updates]
+categories: [fails, deployment, docker]
 ---
 
 ## Introduction

--- a/website/documentation/guides/applications/insecure-configuration.md
+++ b/website/documentation/guides/applications/insecure-configuration.md
@@ -1,9 +1,12 @@
 ---
 title: Auditing Kubernetes for Secure Setup
-description: "A few insecure configurations in Kubernetes"
+description: Learn about security vulnerabilities in Kubernetes configurations including API server privilege escalation, HTTP redirect exploits, and Grafana metadata access issues with remediation strategies.
 level: advanced
 category: Security
 scope: operator
+tags: [security, audit, api-server, privilege-escalation, http-redirects, grafana, metadata-service, network-policies, penetration-testing]
+page_synonyms: [kubernetes security, security audit, privilege escalation, api server security, network security, security vulnerabilities]
+categories: [security, auditing, advanced]
 ---
 
 ![teaser](./images/teaser.svg)

--- a/website/documentation/guides/applications/knative-install.md
+++ b/website/documentation/guides/applications/knative-install.md
@@ -1,10 +1,13 @@
 ---
 title: Install Knative in Gardener Clusters
-description: A walkthrough the steps for installing Knative in Gardener shoot clusters.
+description: Complete walkthrough for installing Knative serverless platform in Gardener shoot clusters including Istio setup, cluster configuration, and domain management.
 level: intermediate
 index: 10
 category: Setup
 scope: app-developer
+tags: [knative, gardener, istio, serverless, installation, cluster-setup, kubectl, serving, eventing]
+page_synonyms: [knative setup, serverless installation, gardener knative, istio knative, cluster installation, knative serving]
+categories: [setup, serverless, installation]
 ---
 
 ## Overview

--- a/website/documentation/guides/applications/missing-registry-permission.md
+++ b/website/documentation/guides/applications/missing-registry-permission.md
@@ -1,11 +1,14 @@
 ---
 title: Container Image Not Pulled
-description: "Wrong Container Image or Invalid Registry Permissions"
+description: "Troubleshoot container image pull failures caused by wrong image names or invalid registry permissions in Kubernetes"
 level: beginner
 reviewer: Tieyan Fu
 last_reviewed: 22.06.2018
 category: Fails
 scope: app-developer
+tags: [container, image, pull, registry, permissions, docker, kubernetes, troubleshooting, errimagepull]
+page_synonyms: [image pull error, container registry, docker pull, image not found, registry credentials]
+categories: [troubleshooting, containers, registry]
 ---
 
 ## Problem

--- a/website/documentation/guides/applications/network-isolation.md
+++ b/website/documentation/guides/applications/network-isolation.md
@@ -1,9 +1,12 @@
 ---
 title: Namespace Isolation
-description: "Deny all traffic from other namespaces"
+description: "Configure Kubernetes NetworkPolicies to deny all traffic from other namespaces while allowing traffic within the same namespace"
 level: advanced
 category: Networking
 scope: app-developer
+tags: [networkpolicy, namespace, isolation, security, traffic, ingress, multi-tenant, calico]
+page_synonyms: [network policy, namespace security, traffic isolation, network segmentation, pod isolation]
+categories: [networking, security, isolation]
 ---
 
 ## Overview

--- a/website/documentation/guides/applications/pod-disruption-budget.md
+++ b/website/documentation/guides/applications/pod-disruption-budget.md
@@ -1,11 +1,15 @@
 ---
 title: Specifying a Disruption Budget for Kubernetes Controllers
+description: "Learn how to configure PodDisruptionBudgets to protect applications from voluntary disruptions during cluster operations"
 level: beginner
 index: 10
 category: Getting Started
 scope: app-developer
 featured: true
 publishdate: 2022-06-21
+tags: [poddisruptionbudget, pdb, disruption, availability, deployment, replicaset, statefulset, hpa]
+page_synonyms: [pod disruption budget, availability protection, voluntary disruption, cluster upgrade protection]
+categories: [availability, deployment, cluster-management]
 ---
 
 ## Introduction of Disruptions

--- a/website/documentation/guides/applications/prometheus.md
+++ b/website/documentation/guides/applications/prometheus.md
@@ -1,9 +1,12 @@
 ---
 title: Using Prometheus and Grafana to Monitor K8s
-description: "How to deploy and configure Prometheus and Grafana to collect and monitor kubelet container metrics"
+description: "Complete guide to deploying and configuring Prometheus and Grafana for monitoring Kubernetes clusters with kubelet container metrics"
 level: advanced
 category: Monitoring
 scope: app-developer
+tags: [prometheus, grafana, monitoring, metrics, helm, kubernetes, observability, alerting, dashboards, time-series]
+page_synonyms: [cluster monitoring, metrics collection, prometheus setup, grafana deployment, kubernetes observability]
+categories: [monitoring, observability, metrics]
 ---
 
 ## Disclaimer

--- a/website/documentation/guides/applications/secure-seccomp.md
+++ b/website/documentation/guides/applications/secure-seccomp.md
@@ -1,8 +1,12 @@
 ---
 title: Custom Seccomp Profile
+description: "Configure custom Seccomp profiles in Kubernetes to restrict system calls and enhance container security"
 level: advanced
 category: Security
 scope: operator
+tags: [seccomp, security, system-calls, linux, kernel, daemonset, configmap, pod-security, container-security]
+page_synonyms: [secure computing mode, system call filtering, container hardening, security profiles]
+categories: [security, containers, hardening]
 ---
 
 ## Overview

--- a/website/documentation/guides/applications/service-cache-control.md
+++ b/website/documentation/guides/applications/service-cache-control.md
@@ -1,9 +1,12 @@
 ---
 title: Out-Dated HTML and JS Files Delivered
-description: "Why is my application always outdated?"
+description: "Troubleshoot outdated web application files caused by NGINX ingress caching and learn how to configure proper cache control"
 level: intermediate
 category: Services
 scope: app-developer
+tags: [cache, nginx, ingress, http-headers, cache-control, web-application, static-files, cache-buster]
+page_synonyms: [nginx caching, ingress cache, http cache control, outdated files, static content caching]
+categories: [web-applications, caching, ingress]
 ---
 
 ## Problem

--- a/website/documentation/guides/client-tools/bash-kubeconfig.md
+++ b/website/documentation/guides/client-tools/bash-kubeconfig.md
@@ -1,12 +1,15 @@
 ---
 title: Kubeconfig Context as bash Prompt
-description: "Expose the active kubeconfig into bash"
+description: "Display the active Kubernetes context in your bash prompt to avoid mistakes when working with multiple clusters"
 level: beginner
 reviewer: Tieyan Fu
 status: Reviewed
 last_reviewed: 29.05.2018
 category: kubectl
 scope: app-developer
+tags: [kubeconfig, bash, prompt, context, kubectl, shell, powershell, cluster-management]
+page_synonyms: [kubernetes context, bash prompt, shell configuration, cluster context display]
+categories: [client-tools, shell, configuration]
 ---
 
 ## Overview

--- a/website/documentation/guides/client-tools/bash-tips.md
+++ b/website/documentation/guides/client-tools/bash-tips.md
@@ -1,12 +1,15 @@
 ---
 title: Fun with kubectl Aliases
-description: "Some bash tips that save you some time"
+description: "Useful bash aliases and shortcuts to speed up your kubectl workflow and terminal productivity"
 level: beginner
 index: 40
 category: kubectl
 scope: app-developer
 publishdate: 2019-01-01
 aliases: [ "/readmore/bash_tips" ]
+tags: [kubectl, bash, aliases, shortcuts, terminal, productivity, shell, profile, completion]
+page_synonyms: [kubectl shortcuts, bash aliases, terminal productivity, shell configuration, kubectl tips]
+categories: [client-tools, productivity, shell]
 ---
 
 ## Speed up Your Terminal Workflow

--- a/website/documentation/guides/client-tools/working-with-kubeconfig.md
+++ b/website/documentation/guides/client-tools/working-with-kubeconfig.md
@@ -1,8 +1,12 @@
 ---
 title:  Organizing Access Using kubeconfig Files
+description: "Create custom kubeconfig files for each user with proper RBAC permissions to enhance security and avoid credential sharing"
 level: intermediate
 category: Security
 scope: app-developer
+tags: [kubeconfig, rbac, serviceaccount, security, credentials, authentication, authorization, cluster-access]
+page_synonyms: [kubernetes access, user credentials, service account, cluster authentication, rbac configuration]
+categories: [security, authentication, access-control]
 ---
 
 ## Overview

--- a/website/documentation/guides/monitoring-and-troubleshooting/analyzing-node-failures.md
+++ b/website/documentation/guides/monitoring-and-troubleshooting/analyzing-node-failures.md
@@ -1,10 +1,13 @@
 ---
 title: Analyzing Node Removal and Failures
-description: "Utilize Gardener's Monitoring and Logging to analyze removal and failures of nodes"
+description: "Use Gardener's monitoring and logging stack to investigate node removals, failures, and identify root causes in Kubernetes clusters"
 level: intermediate
 category: Debugging
 aliases: ["/docs/guides/monitoring-and-troubleshooting/analysing-node-failures/"]
 scope: operator
+tags: [node-failure, troubleshooting, monitoring, logging, machine-controller-manager, cluster-autoscaler, grafana, loki]
+page_synonyms: [node troubleshooting, node analysis, cluster debugging, node removal investigation, machine failure]
+categories: [troubleshooting, monitoring, node-management]
 ---
 
 ## Overview

--- a/website/documentation/guides/monitoring-and-troubleshooting/debug-a-pod.md
+++ b/website/documentation/guides/monitoring-and-troubleshooting/debug-a-pod.md
@@ -1,12 +1,15 @@
 ---
 title: How to Debug a Pod
-description: "Your pod doesn't run as expected. Are there any log files? Where? How could I debug a pod?"
+description: "Comprehensive guide to debugging Kubernetes pods that don't run as expected, covering common failure scenarios, troubleshooting commands, and practical examples for identifying and resolving pod startup and runtime issues."
 level: intermediate
 reviewer: Tieyan Fu
 status: Reviewed
 last_reviewed: 19.06.2018
 category: Debugging
 scope: app-developer
+tags: [debugging, pods, kubernetes, troubleshooting, kubectl, logs, crashloopbackoff, containers, resources, images]
+page_synonyms: [pod debugging, kubernetes troubleshooting, container debugging, pod failures, kubectl debug, pod logs, container crashes]
+categories: [debugging, troubleshooting, monitoring, kubernetes, containers]
 ---
 
 ## Introduction

--- a/website/documentation/guides/monitoring-and-troubleshooting/shell-to-node.md
+++ b/website/documentation/guides/monitoring-and-troubleshooting/shell-to-node.md
@@ -1,9 +1,12 @@
 ---
 title: Get a Shell to a Gardener Shoot Worker Node
-description: "Describes the methods for getting shell access to worker nodes"
+description: "Comprehensive guide for operators to gain shell access to Gardener Shoot worker nodes for troubleshooting, covering multiple methods including Gardener Dashboard, ops-toolbelt, custom pods, and SSH access via bastion hosts for nodes that failed to join the cluster."
 level: advanced
 category: Debugging
 scope: operator
+tags: [shell access, worker nodes, troubleshooting, ssh, bastion, gardenctl, ops-toolbelt, privileged pods, node debugging]
+page_synonyms: [node shell access, worker node ssh, gardener node access, kubernetes node shell, node troubleshooting, bastion host]
+categories: [debugging, troubleshooting, monitoring, infrastructure, nodes]
 ---
 
 ## Overview

--- a/website/documentation/guides/monitoring-and-troubleshooting/tail-logfile.md
+++ b/website/documentation/guides/monitoring-and-troubleshooting/tail-logfile.md
@@ -1,9 +1,12 @@
 ---
 title: tail -f /var/log/my-application.log
-description: "Aggregate log files from different pods"
+description: "Learn how to aggregate and monitor log files from multiple Kubernetes pods simultaneously using kubetail, a bash script that enables tail-like functionality across multiple pod instances for effective log monitoring and debugging."
 level: intermediate
 category: Debugging
 scope: app-developer
+tags: [logs, monitoring, kubetail, pods, aggregation, tail, kubectl, debugging, log files, bash script]
+page_synonyms: [log aggregation, pod logs, kubetail, log monitoring, multiple pod logs, kubernetes logging, log tailing]
+categories: [debugging, monitoring, logging, troubleshooting, tools]
 ---
 
 ## Problem


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the metadata of the documentation pages. This metadata is actually used by docsy to index the pages for the search in the documentation. Meaning that GIGO (garbage in, garbage out) applies.

The good thing is that docsy by default will apply title, description, categories, tags and body by default. If the title is only present, then it heavily swings to search results based on that, without other input to consider.

<img width="851" alt="image" src="https://github.com/user-attachments/assets/19012870-398c-400d-9c1b-a45876bb0e56" />


Updating this metadata will help guide the search 

**Which issue(s) this PR fixes**:
Fixes #
N/A

**Special notes for your reviewer**:
The content of the "bodies" has not changed. The metadata for was generated using an LLM based on the input of the pages and the general gardener documentation.

One note, page_synonyms is currently added but will be used in a later PR to enhance the search even further. For now this should suffice.


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
![image](https://github.com/user-attachments/assets/16655a1f-6cde-4985-90a6-f681ad8d0872)
