### PR TITLE
docs: Clarify where to deploy a custom Prometheus

### DIFF
--- a/website/documentation/getting-started/observability/alerts.md
+++ b/website/documentation/getting-started/observability/alerts.md
@@ -24,9 +24,9 @@ spec:
 
 For more information, see [Alerting](https://github.com/gardener/gardener/blob/master/docs/monitoring/alerting.md).
 
-### Custom Alerts - Federation
+### Custom Alerts – Federation
 
-If you need more customization for alerts for control plane metrics, you have the option to deploy your own Prometheus into your shoot control plane.
+If you need more customization for alerts for control plane metrics, you have the option to deploy your own Prometheus into your shoot cluster.
 
 Then you can use federation, which is a Prometheus feature, to forward the metrics from the Gardener managed Prometheus to your custom deployed Prometheus. Since as a shoot owner you do not have access to the control plane pods, this is the only way to get those metrics.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

A custom Prometheus is deployed, e.g., in a `Shoot` cluster, but not the control plane.

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @rickardsjp 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
