### PR TITLE
fix: Rewrite for trailing slashes

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -8,7 +8,15 @@ export default defineConfig({
   srcDir: 'hugo/content',
   cleanUrls: true,
   rewrites(id) {
-    return id.endsWith('/') ? id.slice(0, -1) : id
+    if (id.endsWith('/index.md') || id.endsWith('/_index.md')) {
+      return id;
+    }
+
+    if (id.endsWith('.md')) {
+      return id.slice(0, -3) + '/index.md';
+    }
+
+    return id;
   },
   srcExclude: [
     '**/archived/**',


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes nasty bug when accessing docs directly via link instead of navigating to it

https://github.com/user-attachments/assets/830e0780-0bbd-4d86-b298-d93b4e9f6e1a

**Which issue(s) this PR fixes**:
Fixes # 
Accessing links that end with a / 
eg.`https://gardener.cloud/docs/gardener/extensions/resources/infrastructure/` instead of `https://gardener.cloud/docs/gardener/extensions/resources/infrastructure`

https://sap-ti.slack.com/archives/G01MH3C9UCS/p1753688573095759

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
Links to articles within the docs work again
```
