### PR TITLE
fix: Convert post processing index.sh to JavaScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
     "docs:preview": "vitepress preview",
     "post-processing-part-1": "node post-processing/part-1.js --rename-images --add-h1-title --youtube --fix-titles --fix-network-doc --add-missing-index",
     "post-processing-part-2": "node post-processing/part-2.js --migrate-alerts --clean-layouts --flatten-single-dirs --add-navigation-frontmatter",
-    "post-processing-index": "chmod +x post-processing/index.sh && ./post-processing/index.sh ./hugo/content",
     "post-processing-part-3": "node post-processing/part-3.js --add-empty-metadata --update-report-link --process-api-html",
-    "post-processing-all": "npm run post-processing-part-1 && npm run post-processing-part-2 && npm run post-processing-index && npm run post-processing-part-3",
+    "post-processing-part-4": "node post-processing/part-4.js ./hugo/content",
+    "post-processing-all": "npm run post-processing-part-1 && npm run post-processing-part-2 && npm run post-processing-part-3 && npm run post-processing-part-4",
 
     "test": "vitest run",
     "test:watch": "vitest"

--- a/post-processing/index.sh
+++ b/post-processing/index.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-set -euo pipefail
-
-find "$1" -type f -name "_index.md" | while read -r file; do
-  dir=$(dirname "$file")
-  cp "$file" "$dir/index.md"
-done

--- a/post-processing/part-4.js
+++ b/post-processing/part-4.js
@@ -1,0 +1,60 @@
+import fs from 'fs';
+import path from 'path';
+
+function findIndexFiles(dir) {
+  const results = [];
+
+  function traverse(currentPath) {
+    try {
+      const entries = fs.readdirSync(currentPath, { withFileTypes: true });
+
+      for (const entry of entries) {
+        const fullPath = path.join(currentPath, entry.name);
+
+        if (entry.isDirectory()) {
+          traverse(fullPath);
+        } else if (entry.name === '_index.md') {
+          results.push(fullPath);
+        }
+      }
+    } catch (error) {
+      console.error(`Error reading directory ${currentPath}:`, error.message);
+    }
+  }
+
+  traverse(dir);
+  return results;
+}
+
+function main() {
+  const targetDir = process.argv[2];
+
+  if (!targetDir) {
+    console.error('Usage: node index.js <directory>');
+    process.exit(1);
+  }
+
+  if (!fs.existsSync(targetDir)) {
+    console.error(`Directory does not exist: ${targetDir}`);
+    process.exit(1);
+  }
+
+  try {
+    const indexFiles = findIndexFiles(targetDir);
+
+    for (const file of indexFiles) {
+      const dir = path.dirname(file);
+      const destinationFile = path.join(dir, 'index.md');
+
+      fs.copyFileSync(file, destinationFile);
+      console.log(`Copied ${file} to ${destinationFile}`);
+    }
+
+    console.log(`Processed ${indexFiles.length} files`);
+  } catch (error) {
+    console.error('Error:', error.message);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
**What this PR does / why we need it**:

Somehow, `post-processing/index.sh` is not found during the Docker build when running on Windows.
Ad-hoc testing with @n-boshnakov did not reveal the root cause of the issue.

As @klocke-io suggested, I converted the script to JavaScript to workaround the issue.

**Which issue(s) this PR fixes**:

_n.a.

**Special notes for your reviewer**:

/cc @n-boshnakov @klocke-io 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
