### PR TITLE
blog: fix link typo in CAPGa blog post

### DIFF
--- a/website/blog/2025/08/08-04-cluster-api-provider-gardener.md
+++ b/website/blog/2025/08/08-04-cluster-api-provider-gardener.md
@@ -107,7 +107,7 @@ As an end user:
 This model significantly reduces the operational burden for the user and promotes standardization and governance, while still offering the flexibility of Cluster API resources and workflows.
 
 > [!TIP]  
-> Further information, especially on the concept of the platform mesh, maintaining a digital twin, and multi-planes, can be found in the [Apeiro documentation](https://documentation.apeirora.eu/best-practices/control-planes/crt).
+> Further information, especially on the concept of the platform mesh, maintaining a digital twin, and multi-planes, can be found in the [Apeiro documentation](https://documentation.apeirora.eu/docs/best-practices/control-planes/crt).
 
 ### Why did we build CAPGa?
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Great post about CAPGa, happy to see kcp mentioned. There is just a little typo in a link.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
