### PR TITLE
fix: Do not rewrite main index page

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -4,15 +4,13 @@ import blogSidebar from './theme/blog-sidebar.ts'
 import {communitySidebar} from "./theme/community-sidebar.ts";
 import path from 'path'
 
+const indexPattern = new RegExp(/\/?_?index\.md$/i);
+
 export default defineConfig({
   srcDir: 'hugo/content',
   cleanUrls: true,
   rewrites(id) {
-    if (id.endsWith('/index.md') || id.endsWith('/_index.md')) {
-      return id;
-    }
-
-    if (id.endsWith('.md')) {
+    if (!indexPattern.test(id) && id.endsWith('.md')) {
       return id.slice(0, -3) + '/index.md';
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

As GitHub Pages does not handle trailing slashes in URLs well, we rewrite all individual pages into a folder and rename them to `index.md`. This way, GitHub Pages resolves the trailing slash as a folder containing an `index.html` file.
However, the previous code rewrites the main index file at the content root, which has the path `index.md`. Rewriting this into a folder is not intended, as it ends up as `index/index.md`.
This PR uses a regex that checks for `/index.md`, `/_index.md`, `index.md`, `_index.md` to skip rewriting.

**Which issue(s) this PR fixes**:

Fixes #700 

**Special notes for your reviewer**:

/cc @klocke-io 

ℹ️ @rfranzke 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
