### PR TITLE
fix: Add trailing slash to sidebar links

### DIFF
--- a/.vitepress/theme/blog-sidebar.ts
+++ b/.vitepress/theme/blog-sidebar.ts
@@ -1,6 +1,6 @@
 import { generateSidebar } from 'vitepress-sidebar';
 import _ from 'lodash-es';
-import {removeIndexEntries} from "./utils/sidebar.ts";
+import { addTrailingSlashToLinks, removeIndexEntries } from './utils/sidebar.ts';
 
 export const blogSidebarConfig = {
     documentRootPath: '/hugo/content',
@@ -53,6 +53,8 @@ function blogSidebar () {
 
   // Filter out all _index.md entries (called last)
   const filteredSidebar = removeIndexEntries(sortedSidebar);
+
+  addTrailingSlashToLinks(filteredSidebar['/blog/'].items);
 
   return filteredSidebar;
 }

--- a/.vitepress/theme/community-sidebar.ts
+++ b/.vitepress/theme/community-sidebar.ts
@@ -1,15 +1,11 @@
 import { generateSidebar } from 'vitepress-sidebar';
-import { writeJsonDebug } from "./utils/debug-json.ts";
+import { writeJsonDebug } from './utils/debug-json.ts';
 import {
-  type SidebarItem,
   removeIndexEntries,
   sortByWeight,
   enhanceDirectoryTitles,
-  createLeafMap,
-  extractItems,
-  filterLeafMapByPersona,
-  filterSidebarByLeafMap,
-  removeEmptyItems
+  removeEmptyItems,
+  addTrailingSlashToLinks,
 } from './utils/sidebar.ts';
 
 const communitySidbarConfig =  {
@@ -47,6 +43,8 @@ export function communitySidebar(): any {
         'cleandCommunitySidebar.json',
         cleandSidebar
     );
+
+    addTrailingSlashToLinks(cleandSidebar['/community/'].items);
 
     return cleandSidebar;
 }

--- a/.vitepress/theme/docs-sidebar.ts
+++ b/.vitepress/theme/docs-sidebar.ts
@@ -1,5 +1,5 @@
 import { generateSidebar } from 'vitepress-sidebar';
-import { writeJsonDebug } from "./utils/debug-json.ts";
+import { writeJsonDebug } from './utils/debug-json.ts';
 import {
   type SidebarItem,
   removeIndexEntries,
@@ -10,7 +10,8 @@ import {
   filterLeafMapByPersona,
   filterSidebarByLeafMap,
   removeEmptyItems,
-  promoteSingleChildLeafs
+  promoteSingleChildLeafs,
+  addTrailingSlashToLinks
 } from './utils/sidebar.ts';
 
 const docsSidbarConfig =  {
@@ -63,6 +64,8 @@ export function generateEnhancedDocsSidebar(): any {
     'cleandSidebar.json',
     cleandSidebar
   );
+
+  addTrailingSlashToLinks(cleandSidebar['/docs/'].items);
 
   return cleandSidebar;
 }

--- a/.vitepress/theme/utils/sidebar.ts
+++ b/.vitepress/theme/utils/sidebar.ts
@@ -548,3 +548,23 @@ export function promoteSingleChildLeafs(sidebar: any): {
   const transformed = processItem(sidebar);
   return { transformed, promotedLeafs };
 }
+
+export function addTrailingSlashToLinks(sidebar: any) {
+  if (Array.isArray(sidebar)) {
+    for (const item of sidebar) {
+      addTrailingSlashToLinks(item)
+    }
+  }
+
+  const link = sidebar.link;
+
+  if (link && link !== 'undefined' && !link.endsWith('/') && !link.endsWith('.md')) {
+    sidebar.link += '/';
+  }
+
+  if (sidebar.items) {
+    for (const item of sidebar.items) {
+      addTrailingSlashToLinks(item)
+    }
+  }
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

The pages of the documentation are resolved with a trailing slash. I haven't yet found the reason for it, as it happens, both when hosted on GitHub Pages, but also locally with the Vitepress development server.
The sidebar highlights the currently active page based on URL matching with the links. As pages are resolved with a trailing slash, but miss the trailing slash in the sidebar, nothing is highlighted.
This PR changes the sidebar generation to include a trailing slash in all links.

**Which issue(s) this PR fixes**:

Fixes #694 

**Special notes for your reviewer**:

/cc @klocke-io @n-boshnakov 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
