### PR TITLE
Add doc on how to debug shoot deletion errors

### DIFF
--- a/website/documentation/guides/monitoring-and-troubleshooting/shoot-deletion-stuck-due-to-unmanaged-resources.md
+++ b/website/documentation/guides/monitoring-and-troubleshooting/shoot-deletion-stuck-due-to-unmanaged-resources.md
@@ -30,29 +30,20 @@ Could not clean all old resources: 1 error occurred: deletion of old resource "v
 ```
 
 1. **Check Resource Status**: Use kubectl to check the status of the resource. You can do this by running:
-   
 ```
 kubectl get service addons-nginx-ingress-controller -n kube-system -o yaml
 ```
 Look for any finalizers or conditions that might be preventing the deletion.
 
-1. **Remove Finalizers**: If the resource has finalizers that are preventing its deletion, you can remove them manually. Edit the resource to remove the finalizers:
-   
+2. **Remove Finalizers**: If the resource has custom finalizers (i.e. not gardener specific, but customer own finalizers) that are preventing its deletion, you can remove them manually. Edit the resource to remove the finalizers:
 ```
 kubectl edit service addons-nginx-ingress-controller -n kube-system
 ```
 Remove the finalizers section from the YAML and save the changes.
 
-1. **Force Delete the Resource**: If the resource is still not deleting, you can forcefully delete it:
-   
-```
-kubectl delete service addons-nginx-ingress-controller -n kube-system --grace-period=0 --force
-```
+3. **Check for Dependencies**: Ensure there are no other resources or dependencies that might be preventing the deletion. This could include other services, endpoints or configurations that depend on the service.
 
-
-1. **Check for Dependencies**: Ensure there are no other resources or dependencies that might be preventing the deletion. This could include other services, endpoints or configurations that depend on the service.
-
-1. **Retry Deletion**: After addressing any issues, retry the deletion process.
+4. **Retry Deletion**: After addressing any issues, retry the deletion process.
 
 ### Case 2: Shoot Stuck Due to OpenStack Networks 
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Sometimes our customers are facing issues trying to delete their shoots due to unmanaged resources they create, extra to what Gardener manages and then they are confused why the deletion cannot finish.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Add documentation for shoot deletion due to unmanaged resources
```
