### PR TITLE
feat: Turn documentation in navbar into a link

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -66,13 +66,18 @@ function getNavConfig () {
       activeMatch: 'adopter',
     },
     {
-      text: 'Documentation',
-      items: [
-        {text: 'User', link: '/docs/index.md',},
-        {text: 'Operator', link: '/docs/index.md',},
-        {text: 'Developer', link: '/docs/index.md',},
-        {text: 'All', link: '/docs/index.md',},
-      ]
+      component: 'VPNavbarMenuGroupWrapper',
+      props: {
+        text: 'Documentation',
+        link: '/docs/',
+        activeMatch: 'docs',
+        items: [
+          {text: 'User', link: '/docs/index.md',},
+          {text: 'Operator', link: '/docs/index.md',},
+          {text: 'Developer', link: '/docs/index.md',},
+          {text: 'All', link: '/docs/index.md',},
+        ],
+      },
     },
     {
       text: 'Blogs',

--- a/.vitepress/theme/components/VPNavbarMenuGroupWrapper.vue
+++ b/.vitepress/theme/components/VPNavbarMenuGroupWrapper.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import VPNavbarMenuGroup from 'vitepress/dist/client/theme-default/components/VPNavBarMenuGroup.vue'
+import VPLink from 'vitepress/dist/client/theme-default/components/VPLink.vue'
+
+const { text, link, activeMatch, items } = defineProps<{
+  text: string,
+  link: string,
+  activeMatch: string,
+  items: any[],
+}>()
+
+function handleClick() {
+  localStorage.setItem('lastClickedMenuItem', 'all')
+  window.dispatchEvent(new CustomEvent('menuItemClicked', {
+    detail: { value: 'all' }
+  }));
+}
+</script>
+
+<template>
+  <VPLink :href="link" @click.self="handleClick">
+    <VPNavbarMenuGroup :item="{ text, activeMatch, items }" />
+  </VPLink>
+</template>

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -3,6 +3,7 @@ import { Theme, useData } from 'vitepress'
 import DefaultTheme from 'vitepress/theme'
 import YouTubeVideo from './components/YouTubeVideo.vue'
 import VPFooter from './components/VPFooter.vue'
+import VPNavbarMenuGroupWrapper from './components/VPNavbarMenuGroupWrapper.vue'
 import EmptyIndexLayout from './layouts/EmptyIndexLayout.vue'
 import './style.css'
 
@@ -19,6 +20,7 @@ export default {
   enhanceApp({ app, router, siteData }) {
     app.component('YouTubeVideo', YouTubeVideo)
     app.component('VPFooter', VPFooter)
+    app.component('VPNavbarMenuGroupWrapper', VPNavbarMenuGroupWrapper)
     
     // Handle 404 detection for both initial loads and SPA navigation
     if (typeof window !== 'undefined') {


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, the top-level navbar entry "Documentation" is not a link. It only shows the dropdown on hover.
This PR turns it into an actual link that allows users to directly visit the documentation.

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @klocke-io 

Squashed cherry-pick of:
* https://github.com/gardener/documentation/commit/ac8169e2aab1a52c765aeef2f9e9398fa2a10ddb
* https://github.com/gardener/documentation/commit/3414ed9f3d2bd5311eea5ce496f23a7a97985a51

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
