### PR TITLE
docs: Add persona mapping for discovery server

### DIFF
--- a/.vitepress/theme/utils/personaMapping.json
+++ b/.vitepress/theme/utils/personaMapping.json
@@ -231,6 +231,8 @@
   "/docs/other-components/dependency-watchdog/setup/": ["Developers"],
   "/docs/other-components/dependency-watchdog/setup/dwd-using-local-garden/": ["Developers"],
   "/docs/other-components/dependency-watchdog/testing/": ["Developers"],
+  "/docs/other-components/gardener-discovery-server/": ["Developers", "Operators"],
+  "/docs/other-components/gardener-discovery-server/api": ["Developers", "Operators"],
   "/docs/other-components/etcd-druid/": ["Developers", "Users"],
   "/docs/other-components/etcd-druid/add-new-etcd-cluster-component/": ["Developers"],
   "/docs/other-components/etcd-druid/api-reference/": ["Developers"],


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, the Gardener Discovery Server does not have any persona mapping associated with its documentation.
I'd argue that this component is only relevant for developers and operators. Hence, this PR adds persona mapping entries for developers and operators.

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @vlerenc @dimityrmirchev 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
