### PR TITLE
docs: Fix relative links on community landing page

### DIFF
--- a/website/community/_index.md
+++ b/website/community/_index.md
@@ -7,7 +7,7 @@ url: /community
 
 The Gardener community is an open, welcoming space where contributors, users, and enthusiasts come together to collaborate, learn, and grow the project. Whether you're just getting started or you're a seasoned contributor, there's a place for you here.
 
-## 🗣️ [Review Meetings](./review-meetings)
+## 🗣️ [Review Meetings](./review-meetings/_index.md)
 
 Join our bi-weekly community meetings where we showcase the latest developments in the Gardener ecosystem. These sessions feature:
 
@@ -18,7 +18,7 @@ Join our bi-weekly community meetings where we showcase the latest developments 
 
 Perfect for staying up-to-date with Gardener's evolution and connecting with the community.
 
-## 🧭 [Project Steering](./steering)
+## 🧭 [Project Steering](./steering/_index.md)
 
 Our governance structure ensures strategic alignment and technical excellence through two steering committees:
 
@@ -27,7 +27,7 @@ Our governance structure ensures strategic alignment and technical excellence th
 
 If you're working on significant features or have ideas that could shape Gardener's future, this is where major decisions are made collaboratively.
 
-## 🔨 [Hackathons](./hackathons)
+## 🔨 [Hackathons](./hackathons/_index.md)
 
 Experience the heart of our community collaboration at our week-long hackathons held twice yearly! These events bring together Gardener enthusiasts from around the world for:
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, the relative links on the community landing page are written intuitively (relative folder name, no file ending).
However, due to this, Docforge does not find an actual document reference and converts the links to their absolute form:

>If a linked document is not a document node in the documentation model, then it will not be downloaded and the link to it is rewritten to its resolved absolute form.

– https://github.com/gardener/docforge/blob/master/docs/consistency.md#links-to-documents

Instead, we specify the relative path with a concrete file reference.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/documentation/issues/749

**Special notes for your reviewer**:

Click on any of the header links on the community landing page:
https://gardener.cloud/community/

/cc @rfranzke @n-boshnakov 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
