### PR TITLE
docs: Improve review meeting outlines

### DIFF
--- a/website/community/review-meetings/2022-community.md
+++ b/website/community/review-meetings/2022-community.md
@@ -1,6 +1,7 @@
 ---
 title: 2022 (Community Meetings)
 weight: -2021
+outline: false
 ---
 
 # Gardener Community Meetings (2022)

--- a/website/community/review-meetings/2022-reviews.md
+++ b/website/community/review-meetings/2022-reviews.md
@@ -1,6 +1,7 @@
 ---
 title: 2022
 weight: -2022
+outline: 3
 ---
 
 # Gardener Review Meetings (2022)

--- a/website/community/review-meetings/2023-reviews.md
+++ b/website/community/review-meetings/2023-reviews.md
@@ -1,6 +1,7 @@
 ---
 title: 2023
 weight: -2023
+outline: 3
 ---
 
 # Gardener Review Meetings (2023)

--- a/website/community/review-meetings/2024-reviews.md
+++ b/website/community/review-meetings/2024-reviews.md
@@ -1,6 +1,7 @@
 ---
 title: 2024
 weight: -2024
+outline: 3
 ---
 
 # Gardener Review Meetings (2024)

--- a/website/community/review-meetings/2025-reviews.md
+++ b/website/community/review-meetings/2025-reviews.md
@@ -1,6 +1,7 @@
 ---
 title: 2025
 weight: -2025
+outline: 3
 ---
 
 # Gardener Review Meetings (2025)


### PR DESCRIPTION
**What this PR does / why we need it**:

_Before:_
<img width="1440" height="1178" alt="Screenshot 2025-11-05 at 09 23 38" src="https://github.com/user-attachments/assets/77cdba6e-febd-48e5-aa7f-fc537d654814" />

_After:_
<img width="1465" height="1209" alt="Screenshot 2025-11-05 at 09 29 11" src="https://github.com/user-attachments/assets/14ae847b-ac3e-48e8-b6d3-85479ef4f008" />

**Which issue(s) this PR fixes**:
Fixes #751 

**Special notes for your reviewer**:

Relevant configuration:
https://vitepress.dev/reference/default-theme-config#outline

I tried changing the outline configuration globally, e.g., with `deep` (showing all heading levels in the outline). However, what works best is highly dependent on the content of the page. Therefore, we should always tailor the outline level using the frontmatter configuration. Using only one number means that only headings of that level are shown (`3` -> `h3` / `###`). It's also possible to use tuples, e.g., `[2, 3]`.

/cc @rfranzke 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
