### PR TITLE
docs: Fix broken link on review meetings page

### DIFF
--- a/website/community/review-meetings/_index.md
+++ b/website/community/review-meetings/_index.md
@@ -24,4 +24,4 @@ This meeting is open to everyone interested in Gardener, from contributors and m
 >
 > If you do not consent to being recorded, please do not enable your microphone or camera, or do not join the meetings.
 
-You can find the recordings and summaries of all previous public community meetings in the [Gardener Review Meetings](./review-meetings/_index.md).
+You can find the recordings and summaries of all previous public community meetings in the [Gardener Review Meetings](./2022-community.md).


### PR DESCRIPTION
**What this PR does / why we need it**:

Most likely, it is meant to point to the historic community meetings page.

**Which issue(s) this PR fixes**:
Fixes #753

**Special notes for your reviewer**:

/cc @rfranzke 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
