### PR TITLE
chore: Update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,22 +1,21 @@
 <!-- Please ensure that you do not include company internal information. -->
 
+**How to categorize this PR?**
+<!--
+Please select a kind for this pull request. This helps the community categorizing it.
+Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
+If multiple identifiers make sense you can also state the command multiple times, e.g.
+  /kind api-change
+  /kind cleanup
+  ...
+
+"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
+-->
+/kind TODO
+
 **What this PR does / why we need it**:
 
 **Which issue(s) this PR fixes**:
 Fixes #
 
 **Special notes for your reviewer**:
-
-**Release note**:
-<!--  Write your release note:
-1. Enter your release note in the below block.
-2. If no release note is required, just write "NONE" within the block.
-
-Format of block header: <category> <target_group>
-Possible values:
-- category:       improvement|noteworthy|action
-- target_group:   user|operator|developer
--->
-```improvement operator
-
-```


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

/kind enhancement

**What this PR does / why we need it**:

Since Prow got enabled for all repositories, it expects a `kind/*` label to be set for PRs.
This change updates the PR template of this repository:
* to include the common template for categorizing the PR.
* removes the release notes section as we (currently) don't build releases in this repository.

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @klocke-io @n-boshnakov 
