### PR TITLE
Use org variable for ok-to-test label

### DIFF
--- a/.github/workflows/pr-preview.yaml
+++ b/.github/workflows/pr-preview.yaml
@@ -12,7 +12,7 @@ concurrency: preview-${{ github.ref }}
 
 jobs:
   deploy-preview:
-    if: ${{ github.event.action == 'labeled' && github.event.label.name == 'ok-to-test' }}
+    if: ${{ github.event.action == 'labeled' && github.event.label.name == vars.DEFAULT_LABEL_OK_TO_TEST && vars.DEFAULT_LABEL_OK_TO_TEST != '' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@v2


### PR DESCRIPTION
/kind cleanup
With this PR one should use the label `ok-to-test` to allow testing to be started when PRs are opened by external contributors.
The label is configured as a variable for the gardener org.
Related to https://github.com/gardener/cc-utils/pull/1512
