### PR TITLE
Add blog introducing-automated-credential-rotation

### DIFF
--- a/website/blog/2026/01/01-28-introducing-automated-credential-rotation.md
+++ b/website/blog/2026/01/01-28-introducing-automated-credential-rotation.md
@@ -1,0 +1,58 @@
+---
+title: "Introducing Automated Credential Rotation"
+linkTitle: "Introducing Automated Credential Rotation"
+newsSubtitle: January 28, 2026
+publishdate: 2026-01-28
+authors:
+- avatar: https://avatars.githubusercontent.com/AleksandarSavchev
+  login: AleksandarSavchev
+  name: Aleksandar Savchev
+aliases: ["/blog/2026/01/28/introducing-automated-credential-rotation"]
+---
+
+Maintaining a strong security posture is crucial for any Kubernetes environment. A key aspect of this is the regular rotation of credentials. To simplify this essential task and reduce operational overhead, Gardener now supports the automatic rotation of several critical credentials during a `Shoot` cluster's maintenance window.
+
+### Enhanced Security, Effortlessly
+
+Previously, users were responsible for manually triggering credential rotations. With this new enhancement, you can now configure your `Shoot` clusters to automatically handle the rotation of:
+
+*   **SSH keypair** for worker nodes
+*   **Observability passwords**
+*   **etcd encryption key**
+
+This ensures that credentials are rotated consistently and on schedule, bolstering the security of your clusters without requiring manual intervention.
+
+### How to Enable Automatic Rotation
+
+You can opt-in to this feature by defining the desired rotation schedule in the `Shoot` manifest under the `.spec.maintenance.autoRotation` field.
+
+During the daily maintenance window, the `gardener-controller-manager` will check if the configured rotation period has passed since the last successful rotation for a given credential. If it has, a new rotation will be initiated automatically.
+
+Here is an example of how to configure it:
+
+```yaml
+spec:
+  maintenance:
+    autoRotation:
+      credentials:
+        # Set this field to enable automatic rotation for observability credentials
+        observability:
+          rotationPeriod: 168h # Rotates every 7 days
+        # Set this field to enable automatic rotation for the SSH keypair
+        sshKeypair:
+          rotationPeriod: 168h # Rotates every 7 days
+        # Set this field to enable automatic rotation for the etcd encryption key
+        etcdEncryptionKey:
+          rotationPeriod: 168h # Rotates every 7 days
+```
+
+If you specify a credential type (like `observability: {}`) but omit the `rotationPeriod`, it will default to `168h` (7 days). The rotation period can be configured to be between 30 minutes and 90 days.
+
+To disable automatic rotation for a specific credential, you can set its `rotationPeriod` to `0`. Manual rotation via annotations remains available if you need to trigger a rotation outside of the scheduled maintenance window.
+
+This new capability makes it easier than ever to follow security best practices, helping you keep your Gardener-managed Kubernetes clusters secure and up-to-date.
+
+### Further Reading
+
+*   [Recording of "Automatic Credentials Rotation During Shoot Maintenance"](https://youtu.be/2rOOsQWLO_w)
+*   [GitHub Pull Request: Add option to automatically rotate credentials in the Maintenance window](https://github.com/gardener/gardener/pull/13493)


### PR DESCRIPTION
## Purpose
@AleksandarSavchev This is an automatically generated draft pull request proposing a new blog post based on your Gardener review meeting presentation you gave on 2026-01-28 titled:

> *"Introducing Automated Credential Rotation"*

The purpose of the blog post is to actively inform the community about new Gardener features or changes, as discussed during review meetings.

## Notes to Reviewers

This draft was automatically generated by LLMs using the review meeting recording and referenced materials.
Please evaluate whether this topic is suitable for a blog post. If so, review and edit the content as needed.
If you decide the topic isn't appropriate for a blog post, feel free to close this PR and delete the branch.

⚠️ This is an experimental GenAI feature. Feedback is welcome! Please direct it to @vlerenc. Thank you!

## Instructions for Reviewers

### ❌ If the draft isn't viable

- Close this PR
- Delete the branch

### ✏️ If the draft is viable but requires editing

1. Clone the repository and change to the directory:
```bash
git clone https://github.com/gardener/documentation
cd documentation
```
2. Check out the branch:
```bash
git fetch origin && git checkout blog/2026-01-28-introducing-automated-credential-rotation
```
3. Review the content in `website/blog/2026/01/01-28-introducing-automated-credential-rotation.md`.
4. Make any necessary edits, additions, or removals, and then push the changes:
```bash
git add website/blog/2026/01/01-28-introducing-automated-credential-rotation.md
git commit --amend --no-edit
git push origin +blog/2026-01-28-introducing-automated-credential-rotation
```

### ✅ If the draft is ready for review

- Mark this PR as **Ready for review**
- Invite additional reviewers (optional step)
- Comment with `/lgtm` to approve (required step)

The documentation team will review your PR, as required by branch protection.
They will merge it once you (and any additional reviewers) have approved it.

@AleksandarSavchev Thank you for helping us share valuable updates from the Gardener project with the community!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added blog post introducing Automated Credential Rotation for Gardener. This new feature enables automatic rotation of SSH keypairs, observability passwords, and etcd encryption keys during Shoot maintenance windows. The opt-in feature supports configurable rotation periods ranging from 30 minutes to 90 days, with a default of 7 days.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->