### PR TITLE
Resolve Docforge file collisions in the auditing extension

### DIFF
--- a/.docforge/documentation/gardener-extensions/others.yaml
+++ b/.docforge/documentation/gardener-extensions/others.yaml
@@ -71,3 +71,22 @@ structure:
       description: Gardener extension controller which deploys an auditlog forwarder sending Kubernetes Audit Events to configured backends.
     source: https://github.com/gardener/gardener-extension-auditing/blob/main/README.md
   - fileTree: https://github.com/gardener/gardener-extension-auditing/tree/main/docs
+    excludeFiles:
+      - operations/configuration.md
+      - operations/event-format.md
+      - usage/configuration.md
+      - usage/event-format.md
+  - file: operations-configuration.md
+    frontmatter:
+      title: Configuring for Garden Clusters
+    source: https://github.com/gardener/gardener-extension-auditing/blob/main/docs/operations/configuration.md
+  - file: operations-event-format.md
+    source: https://github.com/gardener/gardener-extension-auditing/blob/main/docs/operations/event-format.md
+  - file: usage-configuration.md
+    frontmatter:
+      title: Configuring for Shoot Clusters
+    source: https://github.com/gardener/gardener-extension-auditing/blob/main/docs/usage/configuration.md
+  - file: usage-event-format.md
+    frontmatter:
+      title: Audit Event Format (Shoot)
+    source: https://github.com/gardener/gardener-extension-auditing/blob/main/docs/usage/event-format.md


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug cleanup

**What this PR does / why we need it**:

The documentation build is currently failing due to file collisions in Docforge:
```
Error: failed to resolve manifest https://github.com/gardener/documentation/blob/master/.docforge/hugo.yaml. manifest https://github.com/gardener/documentation/blob/master/.docforge/hugo.yaml -> manifest https://github.com/gardener/documentation/blob/master/.docforge/website.yaml -> manifest https://github.com/gardener/documentation/blob/master/.docforge/documentation/documentation.yaml -> manifest https://github.com/gardener/documentation/blob/master/.docforge/documentation/gardener-extensions/gardener-extensions.yaml -> manifest https://github.com/gardener/documentation/blob/master/.docforge/documentation/gardener-extensions/others.yaml -> file 

file: event-format.md
source: https://github.com/gardener/gardener-extension-auditing/blob/main/docs/operations/event-format.md
processor: downloader
frontmatter:
    persona: Operators
type: file
path: content/docs/extensions/others/gardener-extension-auditing

 that will be written in content/docs/extensions/others/gardener-extension-auditing causes collision with: 

file: event-format.md
source: https://github.com/gardener/gardener-extension-auditing/blob/main/docs/usage/event-format.md
processor: downloader
frontmatter:
    persona: Users
type: file
path: content/docs/extensions/others/gardener-extension-auditing

Error: Process completed with exit code 255.
```

The problem is that the [`docs/operations`](https://github.com/gardener/gardener-extension-auditing/tree/main/docs/operations) and [`docs/usage`](https://github.com/gardener/gardener-extension-auditing/tree/main/docs/usage) folders of the auditing extension repository contain files with the same names: `configuration.md` & `event-format.md`.

With the persona plugin enabled, Docforge applies special treatment to `operations` and `usage` folders, such as flattening their content into the target file tree. This, in turn, leads to filename collisions.

This PR changes the Docforge configuration in **this** repository to apply prefixes to the colliding files: `operations-` & `usage-`. Additionally, the frontmatter title is overwritten to provide a better overview in the sidebar.

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @rfranzke @Kostov6 @dimityrmirchev 

**Preview:** https://documentation-demo.gardener.cloud/pr-preview/pr-826/docs/extensions/others/gardener-extension-auditing/
<img width="241" height="620" alt="Screenshot 2026-02-04 at 16 41 39" src="https://github.com/user-attachments/assets/210c7572-fbbe-478a-820b-6b00e69db728" />

