### PR TITLE
Stop rewriting frontmatter titles of auditing extension pages

### DIFF
--- a/.docforge/documentation/gardener-extensions/others.yaml
+++ b/.docforge/documentation/gardener-extensions/others.yaml
@@ -77,16 +77,10 @@ structure:
       - usage/configuration.md
       - usage/event-format.md
   - file: operations-configuration.md
-    frontmatter:
-      title: Configuring for Garden Clusters
     source: https://github.com/gardener/gardener-extension-auditing/blob/main/docs/operations/configuration.md
   - file: operations-event-format.md
     source: https://github.com/gardener/gardener-extension-auditing/blob/main/docs/operations/event-format.md
   - file: usage-configuration.md
-    frontmatter:
-      title: Configuring for Shoot Clusters
     source: https://github.com/gardener/gardener-extension-auditing/blob/main/docs/usage/configuration.md
   - file: usage-event-format.md
-    frontmatter:
-      title: Audit Event Format (Shoot)
     source: https://github.com/gardener/gardener-extension-auditing/blob/main/docs/usage/event-format.md


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind cleanup

**What this PR does / why we need it**:

The frontmatter title changes have been contributed upstream:
* https://github.com/gardener/gardener-extension-auditing/pull/55

No need to rewrite them here anymore.

**Which issue(s) this PR fixes**:

Follow-up to:
* https://github.com/gardener/documentation/pull/826

**Special notes for your reviewer**:

/cc @dimityrmirchev @n-boshnakov 