### PR TITLE
Filter duplicate index pages from search results

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -3,6 +3,7 @@ import { fileURLToPath, URL } from 'node:url'
 import blogSidebar from './theme/blog-sidebar.ts'
 import {communitySidebar} from "./theme/community-sidebar.ts";
 import path from 'path'
+import { SearchResult } from 'minisearch'
 
 const indexPattern = new RegExp(/\/?_?index\.md$/i);
 
@@ -159,7 +160,14 @@ function getSearchConfig() {
               page_synonyms: 3 // Synonyms/alternate terms
             },
             // Fields to search in
-            fields: ['title', 'text', 'headings', 'tags', 'categories', 'description', 'page_synonyms']
+            fields: ['title', 'text', 'headings', 'tags', 'categories', 'description', 'page_synonyms'],
+            // TODO(marc1404): Remove once `_index.md` files are renamed to `index.md`.
+            // Historically our source documentation files are using `_index.md` as the default name for index pages.
+            // Since migrating from Hugo to VitePress, we're using a post-processing step (post-processing/part-index.js) to copy and rename all `_index.md` files to `index.md`.
+            // This leads to duplicate search results since both `_index.md` and `index.md` are indexed by MiniSearch.
+            filter(result: SearchResult) {
+              return !result.id.includes('/_index');
+            },
           }
         }
       }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:

> Historically our source documentation files are using `_index.md` as the default name for index pages.
> Since migrating from Hugo to VitePress, we're using a post-processing step (post-processing/part-index.js) to copy and rename all `_index.md` files to `index.md`.
> This leads to duplicate search results since both `_index.md` and `index.md` are indexed by MiniSearch.

_Example for the root cause of this issue in the local `hugo` folder created by Docforge:_

<img width="2482" height="586" alt="image" src="https://github.com/user-attachments/assets/641fe825-c2ae-4877-9a43-19d9e4da2d8d" />

_Example test for filtered search results locally:_

<img width="1487" height="729" alt="image" src="https://github.com/user-attachments/assets/e6b0aafa-d82a-4db3-8f39-56deab218468" />

**Which issue(s) this PR fixes**:
Fixes #842 

**Special notes for your reviewer**:

/cc @n-boshnakov @klocke-io 