### PR TITLE
Include Gardener Enhancement Proposals (GEPs) through Docforge

### DIFF
--- a/.docforge/documentation/documentation.yaml
+++ b/.docforge/documentation/documentation.yaml
@@ -21,7 +21,7 @@ structure:
       frontmatter:
         title: Security and Compliance
         description: Make sure that your clusters are compliant and secure
-        weight: 30
+        weight: 36
         aliases: ["/docs/security-and-compliance/"]
       source: https://github.com/gardener/.github/blob/main/SECURITY.md
     - file: https://github.com/gardener/diki/blob/main/docs/usage/disa-k8s-stig-shoot.md
@@ -176,6 +176,17 @@ structure:
           - "high-availability/shoot_high_availability_best_practices.md" # already included in ./guides.yaml, avoiding duplicates
           - "high-availability/shoot_high_availability.md" # already included in ./guides.yaml, avoiding duplicates
           - "autoscaling/shoot_pod_autoscaling_best_practices.md" # already included in ./guides.yaml, avoiding duplicates
+  - dir: proposals
+    structure:
+      - file: _index.md
+        frontmatter:
+          title: Proposals
+          weight: 34
+        source: https://github.com/gardener/enhancements/blob/main/geps/README.md
+      - fileTree: https://github.com/gardener/enhancements/tree/main/geps
+        excludeFiles:
+          - README.md
+          - NNNN-gep-template/README.md
   - dir: extensions
     structure:
     - file: _index.md


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

Includes the [Gardener Enhancement Proposals (GEPs)](https://github.com/gardener/enhancements) through Docforge.

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @rfranzke 

> [!NOTE]  
> The rendered titles of the enhancement proposals in the sidebar are not ideal yet. The source files no longer contain a frontmatter section with a `title` field. Instead, the information is kept in a separate `gep.yaml` next to the proposal (similar to the `kep.yaml` files in Kubernetes). In a next step, we could implment a [Docforge](https://github.com/gardener/docforge) plugin that builds the frontmatter information based on a `gep.yaml` file (if present).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated documentation section ordering for improved navigation.
  * Introduced new Proposals section featuring enhancement proposals and related resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->