### PR TITLE
Send failure notification for GitHub Action workflow

### DIFF
--- a/.github/workflows/deploy-github-pages.yaml
+++ b/.github/workflows/deploy-github-pages.yaml
@@ -39,6 +39,17 @@ jobs:
         with:
           path: .vitepress/dist
         if: github.event_name != 'pull_request'
+      - name: Send failure notification
+        uses: gardener/cc-utils/.github/actions/send-mail@master
+        if: ${{ failure() && github.ref == 'refs/heads/master' }}
+        with:
+          subject: GHA workflow ${{ github.workflow_ref }} failed!
+          body: |
+            The following GHA job failed:
+            ${build_job_url}
+          recipients: |
+            niklas.klocke@sap.com
+            marc.vornetran@sap.com
 
   deploy:
     if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

Adds a failure notification to the `build` step so that we're proactively notified in cases of failures on the `master` branch.

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @8R0WNI3 @klocke-io 