### PR TITLE
Updated color of kapa.ai header

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -317,6 +317,7 @@ function getHeadConfig(){
         'data-project-name': 'Gardener',
         'data-project-color': '#009f76',
         'data-modal-header-bg-color': '#009f76',
+        'data-modal-title-color': '#FFFFFF',
         'data-project-logo': 'https://gardener.cloud/gardener-logo-white.svg',
         'data-consent-required': 'true',
         'data-consent-screen-disclaimer': 'This AI assistant uses your questions to provide answers based on Gardener documentation. Your questions and interactions may be anonymously collected and analyzed to improve the search functionality and overall user experience. We don\'t collect any personally identifiable information. By clicking "Accept", you consent to using this AI-powered feature and the collection of your data. AI-generated responses may contain inaccuracies - please verify important information with the official documentation.',


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

This PR updates the color of the kapa.ai header:
<img width="1003" height="377" alt="image" src="https://github.com/user-attachments/assets/9d8e0a74-39fd-4320-9e1c-2247c31ba541" />


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated Kapa widget modal header background to a teal shade (#009f76).
  * Updated Kapa widget modal title color to white (#FFFFFF).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->