### PR TITLE
Added Gardenctl documentation

### DIFF
--- a/.docforge/documentation/documentation.yaml
+++ b/.docforge/documentation/documentation.yaml
@@ -207,7 +207,7 @@ structure:
     structure:
     - file: _index.md
       frontmatter:
-        title: Gardenctl V2
+        title: Gardenctl
         description: The command line interface to control your clusters
         weight: 70
         aliases: ["/docs/gardenctl/"]


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR adds the gardenctl v2 documentation to the public website through the website manifest. 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Some things we could consider improving:
- The gardenctl v2 documentation has 2 folders that contain a single file. Due to the way that folders get added, these would be added with lowercase titles ("concepts", "config"), requiring adding a separate `dir` for each of them, with an index. Additionally, having a folder with a single file in it isn't the best look
- Additionally, all files without specific metadata have their title set to the name of the file in Title Case, leading to commands such as "gardenctl config" that would be written all lowercase appear as "Gardenctl Config"



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized gardenctl-v2 into a hierarchical, directory-based documentation layout (replacing the previous single-file entry)
  * Added new sections: Help, Configuration, Concepts, FAQ, Glossary, Resources, and Contribute
  * Preserved existing project logo and updated manifests to expose the new structured docs to readers
<!-- end of auto-generated comment: release notes by coderabbit.ai -->