### PR TITLE
Add blog no-more-etchosts-a-new-era-for-dns-in-gardeners-local-setup

### DIFF
--- a/website/blog/2026/03/03-18-no-more-etchosts-a-new-era-for-dns-in-gardeners-local-setup.md
+++ b/website/blog/2026/03/03-18-no-more-etchosts-a-new-era-for-dns-in-gardeners-local-setup.md
@@ -1,0 +1,38 @@
+---
+title: "No More `/etc/hosts`: A New Era for DNS in Gardener's Local Setup"
+linkTitle: "No More `/etc/hosts`: A New Era for DNS in Gardener's Local Setup"
+newsSubtitle: March 18, 2026
+publishdate: 2026-03-18
+authors:
+- avatar: https://avatars.githubusercontent.com/cerealsnow
+  login: cerealsnow
+  name: Nick
+aliases: ["/blog/2026/03/18/no-more-etchosts-a-new-era-for-dns-in-gardeners-local-setup"]
+---
+
+Gardener's local development setup has received a significant overhaul, replacing the previous CoreDNS-based system with a more robust and efficient `bind9` DNS server. This change streamlines the development experience by eliminating the need for manual `/etc/hosts` file modifications and introducing near-instant DNS updates.
+
+### The Challenges with the Old DNS Setup
+
+Previously, the local development environment relied on a CoreDNS deployment. While functional, this approach presented several challenges for developers:
+*   **Slow Updates:** DNS changes required writing to a ConfigMap and reloading CoreDNS, a process that could take up to a minute to propagate.
+*   **No Wildcard Support:** The setup lacked support for wildcard `DNSRecords`, which complicated the handling of ingresses.
+*   **Manual Configuration:** Developers had to manually edit their `/etc/hosts` file to resolve `local.gardener.cloud` domains, a cumbersome requirement that had to be managed across different environments like developer machines, CI jobs, and kind nodes.
+
+### A Better Way: Dynamic DNS with BIND9
+
+The new implementation replaces CoreDNS with a proper `bind9` DNS server, which acts as the authoritative server for the `local.gardener.cloud` zone. The most significant change is the complete rewrite of the `DNSRecord` actuator to use RFC 2136 dynamic DNS updates.
+
+This new architecture works by having the `provider-local` controller push DNS updates directly to the `bind9` server whenever a `DNSRecord` object is reconciled. This method offers several key advantages:
+*   **Near-Instant Updates:** DNS changes are propagated almost immediately, removing the lengthy delays of the old system.
+*   **Wildcard Record Support:** Wildcard DNS records now work out of the box, simplifying ingress management.
+*   **Unified DNS Resolution:** The `bind9` server is configured as the upstream resolver for all environments (developer machines, CI workers, and kind nodes), creating a single, consistent source for DNS resolution and removing the need for various hacks and manual file changes.
+
+The only exception to the removal of manual host file entries is for the local container registry. To allow tools like Skaffold to push images without requiring developers to configure insecure registries in their Docker daemon, `registry.local.gardener.cloud` is still mapped to `127.0.0.1` and `::1` in the `/etc/hosts` file.
+
+This substantial rework has not only improved the developer experience but has also resulted in a significant cleanup of the codebase, with over 1,000 lines of code being removed.
+
+### Further Reading
+
+*   [Recording of the presentation](https://youtu.be/JQLnnNJHOew?t=638)
+*   [The pull request on GitHub](https://github.com/gardener/gardener/pull/14062)


### PR DESCRIPTION
## Purpose
@cerealsnow This is an automatically generated draft pull request proposing a new blog post based on your Gardener review meeting presentation you gave on 2026-03-18 titled:

> *"No More `/etc/hosts`: A New Era for DNS in Gardener's Local Setup"*

The purpose of the blog post is to actively inform the community about new Gardener features or changes, as discussed during review meetings.

## Notes to Reviewers

This draft was automatically generated by LLMs using the review meeting recording and referenced materials.
Please evaluate whether this topic is suitable for a blog post. If so, review and edit the content as needed.
If you decide the topic isn't appropriate for a blog post, feel free to close this PR and delete the branch.

⚠️ This is an experimental GenAI feature. Feedback is welcome! Please direct it to @vlerenc. Thank you!

## Instructions for Reviewers

### ❌ If the draft isn't viable

- Close this PR
- Delete the branch

### ✏️ If the draft is viable but requires editing

1. Clone the repository and change to the directory:
```bash
git clone https://github.com/gardener/documentation
cd documentation
```
2. Check out the branch:
```bash
git fetch origin && git checkout blog/2026-03-18-no-more-etchosts-a-new-era-for-dns-in-gardeners-local-setup
```
3. Review the content in `website/blog/2026/03/03-18-no-more-etchosts-a-new-era-for-dns-in-gardeners-local-setup.md`.
4. Make any necessary edits, additions, or removals, and then push the changes:
```bash
git add website/blog/2026/03/03-18-no-more-etchosts-a-new-era-for-dns-in-gardeners-local-setup.md
git commit --amend --no-edit
git push origin +blog/2026-03-18-no-more-etchosts-a-new-era-for-dns-in-gardeners-local-setup
```

### ✅ If the draft is ready for review

- Mark this PR as **Ready for review**
- Invite additional reviewers (optional step)
- Comment with `/lgtm` to approve (required step)

The documentation team will review your PR, as required by branch protection.
They will merge it once you (and any additional reviewers) have approved it.

@cerealsnow Thank you for helping us share valuable updates from the Gardener project with the community!