### PR TITLE
Indent first-level navigation categories

### DIFF
--- a/.vitepress/theme/style.css
+++ b/.vitepress/theme/style.css
@@ -88,6 +88,12 @@ img[src='/search.png'] {
   padding-bottom: 10px;
 }
 
+/* Sidebar: indent all nested items (including level-1 categories) */
+#VPSidebarNav .VPSidebarItem.level-0 > .items {
+  border-left: 1px solid var(--vp-c-divider);
+  padding-left: 16px;
+}
+
 /* GitHub social link styling */
 .VPSocialLink[href*="github"] {
   color: var(--vp-c-text-1);

--- a/.vitepress/theme/style.css
+++ b/.vitepress/theme/style.css
@@ -88,8 +88,8 @@ img[src='/search.png'] {
   padding-bottom: 10px;
 }
 
-/* Sidebar: indent all nested items (including level-1 categories) */
-#VPSidebarNav .VPSidebarItem.level-0 > .items {
+/* Sidebar: indent embedded/nested categories, but not top-level wrapper groups */
+#VPSidebarNav .VPSidebarItem.level-0 > .item + .items {
   border-left: 1px solid var(--vp-c-divider);
   padding-left: 16px;
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind task

**What this PR does / why we need it**:

Adds indentation to first-level navigation categories. Top-level categories remain aligned to the left.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/documentation/issues/904

**Special notes for your reviewer**:
/cc @n-boshnakov @klocke-io 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced visual presentation of documentation sidebar navigation with improved spacing and visual separation for nested category items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->