### PR TITLE
Fix broken links in List of Extensions

### DIFF
--- a/.vitepress/theme/components/TaxonomyIndex.vue
+++ b/.vitepress/theme/components/TaxonomyIndex.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { useData } from 'vitepress'
 import { computed } from 'vue'
+// VPLink normalizes hrefs via cleanUrls (strips .md), matching how sidebar links are handled
+import VPLink from 'vitepress/dist/client/theme-default/components/VPLink.vue'
 
 const { frontmatter, page } = useData()
 
@@ -16,7 +18,7 @@ const pageTitle = computed(() => {
     <h1>{{ pageTitle }}</h1>
     <ul class="taxonomy-list">
       <li v-for="child in children" :key="child.link">
-        <a :href="child.link">{{ child.text }}</a>
+        <VPLink :href="child.link">{{ child.text }}</VPLink>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:

Fixes the broken links in the auto-generated taxonomies of the [List of Extensions](https://gardener.cloud/docs/extensions/) section by:
-  Importing the `VPLink` component into our custom `TaxonomyIndex` component
- Using `VPLink` to resolve `index.md` links to clean URLs (consistent with how the sidebar handles them)

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/documentation/issues/892

**Special notes for your reviewer**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved link handling in taxonomy navigation to ensure consistent URL normalization and proper link behavior across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->