### PR TITLE
Add missing Network Problem Detector content

### DIFF
--- a/.docforge/documentation/other-components.yaml
+++ b/.docforge/documentation/other-components.yaml
@@ -47,4 +47,6 @@ structure:
       title: Network Problem Detector
       description: A tool which diagnoses network issues in Kubernetes clusters by performing various connectivity checks
     source: https://github.com/gardener/network-problem-detector/blob/main/README.md
-    
+  - fileTree: https://github.com/gardener/network-problem-detector/tree/main/docs
+    excludeFiles:
+    - "README.md"

--- a/.docforge/documentation/other-components.yaml
+++ b/.docforge/documentation/other-components.yaml
@@ -47,3 +47,4 @@ structure:
       title: Network Problem Detector
       description: A tool which diagnoses network issues in Kubernetes clusters by performing various connectivity checks
     source: https://github.com/gardener/network-problem-detector/blob/main/README.md
+    

--- a/.docforge/documentation/other-components.yaml
+++ b/.docforge/documentation/other-components.yaml
@@ -47,6 +47,3 @@ structure:
       title: Network Problem Detector
       description: A tool which diagnoses network issues in Kubernetes clusters by performing various connectivity checks
     source: https://github.com/gardener/network-problem-detector/blob/main/README.md
-  - fileTree: https://github.com/gardener/network-problem-detector/tree/main/docs
-    excludeFiles:
-    - "README.md"

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -59,8 +59,6 @@ export default defineConfig({
     //'**/api-reference/core.md',
     //'**/etcd-druid/api-reference.md',
     //'**/machine-controller-manager/documents/apis.md',
-    // Missing end tag <> used in normal text not in code block
-    '**/other-components/network-problem-detector/**',
     // Custom template tag is used instead of normal markdown alert or github alert
     // https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts
     //'**/tutorials/tutorial-custom-domain-with-istio.md',


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:

Fixes the [Network Problem Detector](https://gardener.cloud/docs/other-components/network-problem-detector/) page ~~by removing the `fileTree` field for the directory in `other-components.yaml`. Since the documentation at https://github.com/gardener/network-problem-detector/tree/main/docs doesn't contain any Markdown files, adding the `fileTree` link led to an issue.~~

In `config.mts`, there was a source exclusion for  `**/other-components/network-problem-detector/**`. Removing the exclusion, resolved the issue. Deleting the `fileTree` field was not required, so the corresponding commit was reverted.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/documentation/issues/888

**Special notes for your reviewer**:
/cc @n-boshnakov 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Fixed a documentation exclusion entry formatting to restore correct exclusion of a README file.
  * Re-enabled previously excluded component documentation so those pages will now be processed and appear on the site.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->