### PR TITLE
Remove empty Observability section

### DIFF
--- a/.docforge/documentation/documentation.yaml
+++ b/.docforge/documentation/documentation.yaml
@@ -123,14 +123,6 @@ structure:
           frontmatter:
             title: Networking
             weight: 40
-      - dir: observability
-        frontmatter:
-          aliases: ["/docs/gardener"]
-        structure:
-        - file: _index.md
-          frontmatter:
-            title: Observability
-            weight: 50
       - dir: project
         frontmatter:
           aliases: ["/docs/gardener"]


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:

Currently, the [Gardener > Observability](https://gardener.cloud/docs/gardener/observability/) section has no content because the `observability` directory has been deleted from [the source directory](https://github.com/gardener/gardener/tree/master/docs/usage). The directory contained only one file (`logging.md`), which is now displayed as a page directly under the Gardener section: http://localhost:5173/docs/gardener/logging/.

The current PR removes the empty Observability section from `documentation.yaml`.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/documentation/issues/915

**Special notes for your reviewer**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Removed observability documentation from the usage section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->