### PR TITLE
Add stop word filtering to MiniSearch

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -156,8 +156,31 @@ function getSearchConfig() {
             },
             // Custom tokenizer to handle special characters in technical docs
             tokenize: (text) => text.toLowerCase().split(/[\s\-_/]+/),
-            // Process terms to improve search (e.g., stemming)
-            processTerm: (term) => term.toLowerCase()
+            // Filter stopwords and normalize terms
+            processTerm: (term) => {
+              const normalized = term.toLowerCase();
+              // Stopwords inlined here because this function is serialized into the build worker
+              // and cannot reference variables from the outer module scope.
+              const stopwords = new Set([
+                // Articles & determiners
+                'a', 'an', 'the',
+                // Conjunctions & prepositions
+                'and', 'or', 'but', 'nor',
+                'in', 'on', 'at', 'to', 'for', 'of', 'from', 'with', 'by', 'as', 'into',
+                // Auxiliary & modal verbs
+                'is', 'are', 'was', 'were', 'be', 'been', 'being',
+                'have', 'has', 'had',
+                'do', 'does', 'did',
+                'will', 'would', 'could', 'should', 'may', 'might', 'shall',
+                // Pronouns
+                'i', 'we', 'you', 'he', 'she', 'it', 'they',
+                'this', 'that', 'these', 'those',
+                // Common filler
+                'not', 'no', 'only', 'just', 'also', 'both',
+                'than', 'then', 'too', 'very', 'such',
+              ]);
+              return stopwords.has(normalized) ? null : normalized;
+            }
           },
           /**
            * @type {import('minisearch').SearchOptions}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
The PR adds stop word filtering to the MiniSearch configuration, so that articles ("a", "the"), prepositions, and other semantically irrelevant tokens are excluded during search processing.

**Which issue(s) this PR fixes**:
Related to https://github.com/gardener/documentation/issues/812

**Special notes for your reviewer**:
/cc @klocke-io 