### PR TITLE
Move "Edit this page" link to the right-hand side

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -239,7 +239,7 @@ function getThemeConfig() {
       siteHostname: 'https://gardener.cloud',
       links: [
         {
-          text: 'Edit this page on GitHub',
+          text: 'Edit this page',
           icon: 'vpi-square-pen',
           url: ({filePath, frontmatter}: {filePath: string, frontmatter: Record<string, any>}) => {
             if (!frontmatter['github_repo'] || !frontmatter['github_subdir']) return undefined
@@ -248,11 +248,11 @@ function getThemeConfig() {
           },
         },
         {
-          text: 'Report a documentation issue',
+          text: 'Report an issue',
           icon: 'vpi-report-issue',
           url: ({pageTitle, pageUrl}: {pageTitle: string, pageUrl: string}) => {
             const title = encodeURIComponent(pageTitle)
-            const body = encodeURIComponent(`<!-- What's the issue? -->\n\n\n**URL:** ${pageUrl}\n\n`)
+            const body = encodeURIComponent(`**Description:**\n<!-- Please describe the issue. -->\n\n**Screenshots:**\n<!-- Add screenshots if possible. -->\n\n**URL:** ${pageUrl}\n\n`)
             return `https://github.com/gardener/documentation/issues/new?title=${title}&body=${body}`
           },
         },

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -242,6 +242,7 @@ function getThemeConfig() {
           text: 'Edit this page on GitHub',
           icon: 'vpi-square-pen',
           url: ({filePath, frontmatter}: {filePath: string, frontmatter: Record<string, any>}) => {
+            if (!frontmatter['github_repo'] || !frontmatter['github_subdir']) return undefined
             const fileName = `${frontmatter?.path_base_for_github_subdir?.to ?? filePath.split("/").pop()}`
             return `${frontmatter['github_repo']}/tree/master/${frontmatter['github_subdir']}/${fileName}`
           },

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -242,7 +242,7 @@ function getThemeConfig() {
         },
         {
           text: 'Report a documentation issue',
-          icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>',
+          icon: 'vpi-report-issue',
           url: ({pageTitle, pageUrl}: {pageTitle: string, pageUrl: string}) => {
             const title = encodeURIComponent(pageTitle)
             const body = encodeURIComponent(`<!-- What's the issue? -->\n\n\n**URL:** ${pageUrl}\n\n`)

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -248,7 +248,7 @@ function getThemeConfig() {
         },
         {
           text: 'Report a documentation issue',
-          icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>',
+          icon: 'vpi-report-issue',
           url: ({pageTitle, pageUrl}: {pageTitle: string, pageUrl: string}) => {
             const title = encodeURIComponent(pageTitle)
             const body = encodeURIComponent(`<!-- What's the issue? -->\n\n\n**URL:** ${pageUrl}\n\n`)

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -257,6 +257,9 @@ function getThemeConfig() {
         },
       ],
     },
+    outline: {
+      label: 'Page Content'
+    },
     socialLinks: [
       {
         icon: {

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -235,13 +235,27 @@ function getThemeConfig() {
     },
     nav: getNavConfig(),
     sidebar: allSidebars,
-    editLink: {
-      pattern: ({filePath, frontmatter}: {filePath: string, frontmatter: Record<string, any>}) => {
-        const fileName = `${frontmatter?.path_base_for_github_subdir?.to ?? filePath.split("/").pop()}`
-        const githubLink = `${frontmatter['github_repo']}/tree/master/${frontmatter['github_subdir']}/${fileName}`
-        return githubLink
-      },
-      text: 'Edit this page on GitHub'
+    pageActions: {
+      siteHostname: 'https://gardener.cloud',
+      links: [
+        {
+          text: 'Edit this page on GitHub',
+          icon: 'vpi-square-pen',
+          url: ({filePath, frontmatter}: {filePath: string, frontmatter: Record<string, any>}) => {
+            const fileName = `${frontmatter?.path_base_for_github_subdir?.to ?? filePath.split("/").pop()}`
+            return `${frontmatter['github_repo']}/tree/master/${frontmatter['github_subdir']}/${fileName}`
+          },
+        },
+        {
+          text: 'Report a documentation issue',
+          icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>',
+          url: ({pageTitle, pageUrl}: {pageTitle: string, pageUrl: string}) => {
+            const title = encodeURIComponent(pageTitle)
+            const body = encodeURIComponent(`<!-- What's the issue? -->\n\n\n**URL:** ${pageUrl}\n\n`)
+            return `https://github.com/gardener/documentation/issues/new?title=${title}&body=${body}`
+          },
+        },
+      ],
     },
     socialLinks: [
       {

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -229,13 +229,27 @@ function getThemeConfig() {
     },
     nav: getNavConfig(),
     sidebar: allSidebars,
-    editLink: {
-      pattern: ({filePath, frontmatter}: {filePath: string, frontmatter: Record<string, any>}) => {
-        const fileName = `${frontmatter?.path_base_for_github_subdir?.to ?? filePath.split("/").pop()}`
-        const githubLink = `${frontmatter['github_repo']}/tree/master/${frontmatter['github_subdir']}/${fileName}`
-        return githubLink
-      },
-      text: 'Edit this page on GitHub'
+    pageActions: {
+      siteHostname: 'https://gardener.cloud',
+      links: [
+        {
+          text: 'Edit this page on GitHub',
+          icon: 'vpi-square-pen',
+          url: ({filePath, frontmatter}: {filePath: string, frontmatter: Record<string, any>}) => {
+            const fileName = `${frontmatter?.path_base_for_github_subdir?.to ?? filePath.split("/").pop()}`
+            return `${frontmatter['github_repo']}/tree/master/${frontmatter['github_subdir']}/${fileName}`
+          },
+        },
+        {
+          text: 'Report a documentation issue',
+          icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>',
+          url: ({pageTitle, pageUrl}: {pageTitle: string, pageUrl: string}) => {
+            const title = encodeURIComponent(pageTitle)
+            const body = encodeURIComponent(`<!-- What's the issue? -->\n\n\n**URL:** ${pageUrl}\n\n`)
+            return `https://github.com/gardener/documentation/issues/new?title=${title}&body=${body}`
+          },
+        },
+      ],
     },
     socialLinks: [
       {

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -236,6 +236,7 @@ function getThemeConfig() {
           text: 'Edit this page on GitHub',
           icon: 'vpi-square-pen',
           url: ({filePath, frontmatter}: {filePath: string, frontmatter: Record<string, any>}) => {
+            if (!frontmatter['github_repo'] || !frontmatter['github_subdir']) return undefined
             const fileName = `${frontmatter?.path_base_for_github_subdir?.to ?? filePath.split("/").pop()}`
             return `${frontmatter['github_repo']}/tree/master/${frontmatter['github_subdir']}/${fileName}`
           },

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -251,6 +251,9 @@ function getThemeConfig() {
         },
       ],
     },
+    outline: {
+      label: 'Page Content'
+    },
     socialLinks: [
       {
         icon: {

--- a/.vitepress/theme/components/PageActions.vue
+++ b/.vitepress/theme/components/PageActions.vue
@@ -17,21 +17,47 @@ Register in .vitepress/theme/index.ts:
 import { computed } from 'vue'
 import { useData } from 'vitepress'
 
+interface LinkContext {
+  filePath: string
+  frontmatter: Record<string, unknown>
+  pageTitle: string
+  pageUrl: string
+}
+
+interface LinkConfig {
+  text: string
+  icon: string
+  url: string | ((context: LinkContext) => string | undefined)
+}
+
+interface PageActionsConfig {
+  siteHostname?: string
+  links?: LinkConfig[]
+}
+
+interface ResolvedLink {
+  text: string
+  icon: string
+  url: string
+}
+
 const { theme, page, frontmatter } = useData()
 
-const links = computed(() => {
-  const config = theme.value.pageActions
+const links = computed<ResolvedLink[]>(() => {
+  const config = theme.value.pageActions as PageActionsConfig | undefined
   if (!config || frontmatter.value.editLink === false) return []
 
   const siteHostname = config.siteHostname ?? ''
   const pageUrl = `${siteHostname}/${page.value.relativePath.replace(/\.md$/, '')}`
-  const context = { filePath: page.value.filePath, frontmatter: frontmatter.value, pageTitle: page.value.title, pageUrl }
+  const context: LinkContext = { filePath: page.value.filePath, frontmatter: frontmatter.value, pageTitle: page.value.title, pageUrl }
 
-  return (config.links ?? []).map((link: any) => ({
-    text: link.text,
-    icon: link.icon,
-    url: typeof link.url === 'function' ? link.url(context) : link.url,
-  })).filter((link: any) => link.url)
+  return (config.links ?? [])
+    .map((link) => ({
+      text: link.text,
+      icon: link.icon,
+      url: typeof link.url === 'function' ? link.url(context) : link.url,
+    }))
+    .filter((link): link is ResolvedLink => !!link.url)
 })
 </script>
 

--- a/.vitepress/theme/components/PageActions.vue
+++ b/.vitepress/theme/components/PageActions.vue
@@ -101,6 +101,12 @@ const links = computed<ResolvedLink[]>(() => {
   height: 16px;
 }
 
+.vpi-report-issue {
+  --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'/%3E%3Cline x1='12' y1='8' x2='12' y2='12'/%3E%3Cline x1='12' y1='16' x2='12.01' y2='16'/%3E%3C/svg%3E");
+  width: 16px;
+  height: 16px;
+}
+
 .svg-icon {
   display: inline-flex;
   width: 16px;

--- a/.vitepress/theme/components/PageActions.vue
+++ b/.vitepress/theme/components/PageActions.vue
@@ -1,0 +1,94 @@
+<!--
+Custom component that renders page-level action links in the aside.
+Configured via `pageActions` in config.mts:
+  - `siteHostname` (string): used to build the full page URL passed to url functions
+  - `links` (array): links to render, each with:
+      - `text` (string): link label
+      - `icon` (string): CSS class name (e.g. 'vpi-square-pen') or inline SVG string
+      - `url` (string | function): static URL or function receiving
+        { filePath, frontmatter, pageTitle, pageUrl }
+
+Recommended slot: `aside-outline-before` (top of the right sidebar, above the TOC).
+Register in .vitepress/theme/index.ts:
+  'aside-outline-before': () => h(PageActions)
+-->
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useData } from 'vitepress'
+
+const { theme, page, frontmatter } = useData()
+
+const links = computed(() => {
+  const config = theme.value.pageActions
+  if (!config || frontmatter.value.editLink === false) return []
+
+  const siteHostname = config.siteHostname ?? ''
+  const pageUrl = `${siteHostname}/${page.value.relativePath.replace(/\.md$/, '')}`
+  const context = { filePath: page.value.filePath, frontmatter: frontmatter.value, pageTitle: page.value.title, pageUrl }
+
+  return (config.links ?? []).map((link: any) => ({
+    text: link.text,
+    icon: link.icon,
+    url: typeof link.url === 'function' ? link.url(context) : link.url,
+  })).filter((link: any) => link.url)
+})
+</script>
+
+<template>
+  <div v-if="links.length" class="edit-this-page">
+    <a v-for="link in links" :key="link.text" :href="link.url" target="_blank" rel="noreferrer">
+      <span v-if="!link.icon.includes('<')" :class="link.icon" aria-hidden="true" />
+      <span v-else class="svg-icon" aria-hidden="true" v-html="link.icon" />
+      {{ link.text }}
+    </a>
+  </div>
+</template>
+
+<style scoped>
+.edit-this-page {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-bottom: 16px;
+}
+
+.edit-this-page a {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border: 0;
+  line-height: 32px;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--vp-c-brand-1);
+  text-decoration: none;
+  transition: color 0.25s;
+}
+
+.edit-this-page a:hover {
+  color: var(--vp-c-brand-2);
+}
+
+.vpi-square-pen {
+  width: 16px;
+  height: 16px;
+}
+
+.svg-icon {
+  display: inline-flex;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
+.svg-icon :deep(svg) {
+  width: 16px;
+  height: 16px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+</style>

--- a/.vitepress/theme/components/PageActions.vue
+++ b/.vitepress/theme/components/PageActions.vue
@@ -4,7 +4,8 @@ Configured via `pageActions` in config.mts:
   - `siteHostname` (string): used to build the full page URL passed to url functions
   - `links` (array): links to render, each with:
       - `text` (string): link label
-      - `icon` (string): CSS class name (e.g. 'vpi-square-pen') or inline SVG string
+      - `icon` (string): CSS class name (e.g. 'vpi-square-pen', 'vpi-report-issue').
+        To add more icons, define them as CSS mask classes in this file.
       - `url` (string | function): static URL or function receiving
         { filePath, frontmatter, pageTitle, pageUrl }
 
@@ -48,7 +49,7 @@ const links = computed<ResolvedLink[]>(() => {
   if (!config || frontmatter.value.editLink === false) return []
 
   const siteHostname = config.siteHostname ?? ''
-  const pageUrl = `${siteHostname}/${page.value.relativePath.replace(/\.md$/, '')}`
+  const pageUrl = `${siteHostname}/${page.value.relativePath.replace(/\.md$/, '').replace(/\/index$/, '/')}`
   const context: LinkContext = { filePath: page.value.filePath, frontmatter: frontmatter.value, pageTitle: page.value.title, pageUrl }
 
   return (config.links ?? [])
@@ -64,8 +65,7 @@ const links = computed<ResolvedLink[]>(() => {
 <template>
   <div v-if="links.length" class="edit-this-page">
     <a v-for="link in links" :key="link.text" :href="link.url" target="_blank" rel="noreferrer">
-      <span v-if="!link.icon.includes('<')" :class="link.icon" aria-hidden="true" />
-      <span v-else class="svg-icon" aria-hidden="true" v-html="link.icon" />
+      <span :class="link.icon" aria-hidden="true" />
       {{ link.text }}
     </a>
   </div>
@@ -105,22 +105,5 @@ const links = computed<ResolvedLink[]>(() => {
   --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'/%3E%3Cline x1='12' y1='8' x2='12' y2='12'/%3E%3Cline x1='12' y1='16' x2='12.01' y2='16'/%3E%3C/svg%3E");
   width: 16px;
   height: 16px;
-}
-
-.svg-icon {
-  display: inline-flex;
-  width: 16px;
-  height: 16px;
-  flex-shrink: 0;
-}
-
-.svg-icon :deep(svg) {
-  width: 16px;
-  height: 16px;
-  fill: none;
-  stroke: currentColor;
-  stroke-width: 2;
-  stroke-linecap: round;
-  stroke-linejoin: round;
 }
 </style>

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -7,6 +7,7 @@ import VPFooter from './components/VPFooter.vue'
 import TaxonomyIndex from './components/TaxonomyIndex.vue'
 import Banner from './components/Banner.vue'
 import BlogPostMeta from './components/BlogPostMeta.vue'
+import PageActions from './components/PageActions.vue'
 import './style.css'
 
 
@@ -16,6 +17,7 @@ export default {
     return h(DefaultTheme.Layout, null, {
       'doc-before': () => h(TaxonomyIndex),
       'aside-top': () => h(BlogPostMeta),
+      'aside-outline-before': () => h(PageActions),
       'home-features-before': () => h(Banner),
       'layout-bottom': () => h(VPFooter),
     })

--- a/.vitepress/theme/style.css
+++ b/.vitepress/theme/style.css
@@ -133,3 +133,8 @@ img[src='/search.png'] {
     padding: 18px 12px;
   }
 }
+
+/* Edit link moved to aside-outline-before; hide the default footer position */
+.VPDocFooter .edit-link {
+  display: none;
+}

--- a/.vitepress/theme/style.css
+++ b/.vitepress/theme/style.css
@@ -133,8 +133,3 @@ img[src='/search.png'] {
     padding: 18px 12px;
   }
 }
-
-/* Edit link moved to aside-outline-before; hide the default footer position */
-.VPDocFooter .edit-link {
-  display: none;
-}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

- Adds a custom PageActions Vue component and uses the component for rendering the "Edit this page" link in the top-right corner.
- Adds a "Report a documentation issue" link.
- Changes the table-of contents title from "On this page" to "Page Content".

<img width="1164" height="694" alt="image" src="https://github.com/user-attachments/assets/c3788d4b-5f49-4a8e-bd3a-26744e5c90d3" />

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/documentation/issues/692

**Special notes for your reviewer**:
/cc @n-boshnakov @marc1404 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Documentation pages now display action links in the sidebar for editing content and reporting issues directly from the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->