### PR TITLE
Add Steering page for Gardener Landscape Kit

### DIFF
--- a/website/community/steering/0049-gardener-landscape-kit.md
+++ b/website/community/steering/0049-gardener-landscape-kit.md
@@ -1,0 +1,14 @@
+---
+title: "GEP-0049: Gardener Landscape Kit"
+---
+
+- 📌 **GEP Tracking Issue:** https://github.com/gardener/enhancements/issues/49
+- 📖 **GEP Link:** https://github.com/gardener/enhancements/pull/48
+- ✍🏻 **Author(s):** [@timuthy](https://github.com/timuthy) (Tim Usner)
+- 🗓️ **Presentation:** 2026-03-25, 15:00 - 16:00 CET
+- 🎥 **Recording:** https://youtu.be/VHi-y3chH1s
+- 👨‍⚖️ **Decisions & Agreements:**
+  - Currently, the resolution of the three way merge is automatic, but it is possible to make the conflicts visible to operators so that they can be manually addressed instead => Adapted https://github.com/gardener/enhancements/pull/48 accordingly
+  - At the moment, Gardener Landscape Kit is primarily git-based. An alternative approach could be to allow OCI-based repositories => Adapted https://github.com/gardener/enhancements/pull/48 accordingly
+  - The version vector provided per default might not be qualified, i.e. there might not be a test coverage for the version vector. There will be a follow-up discussion whether some qualified/tested combination of component versions could be provided.
+  - The proposal is good overall and shall be implemented.

--- a/website/community/steering/0049-gardener-landscape-kit.md
+++ b/website/community/steering/0049-gardener-landscape-kit.md
@@ -10,5 +10,5 @@ title: "GEP-0049: Gardener Landscape Kit"
 - 👨‍⚖️ **Decisions & Agreements:**
   - Currently, the resolution of the three-way merge is automatic, but it is possible to make conflicts visible to operators so they can be addressed manually instead => Adapted https://github.com/gardener/enhancements/pull/48 accordingly
   - At the moment, Gardener Landscape Kit is primarily git-based. An alternative approach could be to allow OCI-based repositories => Adapted https://github.com/gardener/enhancements/pull/48 accordingly
-  - The version vector provided per default might not be qualified, i.e. there might not be a test coverage for the version vector. There will be a follow-up discussion whether some qualified/tested combination of component versions could be provided.
+  - The default version vector might not be qualified, i.e. there might not be test coverage for it. There will be a follow-up discussion on whether some qualified/tested combination of component versions can be provided.
   - The proposal is good overall and shall be implemented.

--- a/website/community/steering/0049-gardener-landscape-kit.md
+++ b/website/community/steering/0049-gardener-landscape-kit.md
@@ -8,7 +8,7 @@ title: "GEP-0049: Gardener Landscape Kit"
 - 🗓️ **Presentation:** 2026-03-25, 15:00 - 16:00 CET
 - 🎥 **Recording:** https://youtu.be/VHi-y3chH1s
 - 👨‍⚖️ **Decisions & Agreements:**
-  - Currently, the resolution of the three way merge is automatic, but it is possible to make the conflicts visible to operators so that they can be manually addressed instead => Adapted https://github.com/gardener/enhancements/pull/48 accordingly
+  - Currently, the resolution of the three-way merge is automatic, but it is possible to make conflicts visible to operators so they can be addressed manually instead => Adapted https://github.com/gardener/enhancements/pull/48 accordingly
   - At the moment, Gardener Landscape Kit is primarily git-based. An alternative approach could be to allow OCI-based repositories => Adapted https://github.com/gardener/enhancements/pull/48 accordingly
   - The version vector provided per default might not be qualified, i.e. there might not be a test coverage for the version vector. There will be a follow-up discussion whether some qualified/tested combination of component versions could be provided.
   - The proposal is good overall and shall be implemented.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

Add Steering page for Gardener Landscape Kit.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/cc @rfranzke @timebertt @vlerenc @timuthy 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new steering page for GEP-0049 with title, author, presentation schedule, recording link, and links to the tracking issue and PR.
  * Records Decisions & Agreements: automatic three-way-merge resolution (with optional manual conflict surfacing), git-first repo approach (OCI as an option), concerns and follow-up on version qualification/testing, and approval to implement the proposal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->