### PR TITLE
Fix broken image reference

### DIFF
--- a/website/community/hackathons/2026-05.md
+++ b/website/community/hackathons/2026-05.md
@@ -12,7 +12,7 @@ outline: 2
 - 📘 **Topics:** tbd
 - 🎤 **Review Meeting Summary:** tbd
 
-![Group picture](./images/2026-05/group-picture.jpeg)
+[Uncomment once the group picture is available]: # (![Group picture]&#40;./images/2026-05/group-picture.jpeg&#41;)
 
 <hr />
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind cleanup

**What this PR does / why we need it**:

The build is currently broken due to a missing image reference.
This change comments the image line to be included once available.

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:
/cc @rfranzke 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the group picture image from the 2026-05 hackathon page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->