### PR TITLE
Add `netlify.toml` configuration to set `X-Frame-Options` header to `DENY`

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[headers]]
+    for = "/*"
+    [headers.values]
+        X-Frame-Options = "DENY"


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

Although there's (currently) no real risk from clickjacking attacks and alike, we still would like to set the `X-Frame-Options: DENY` header. Using Netlify, this can be done with a special `_headers` file in the public directory's root or with the `netlify.toml` file. I find the latter more explicit, and it allows for better configuration options ([ref](https://docs.netlify.com/build/configure-builds/file-based-configuration/#headers)).

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

Once the preview has been deployed by Netlify, we can verify that the response header is set appropriately.

/cc @HeckEK @n-boshnakov 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added X-Frame-Options header configuration to apply across all application routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->