### PR TITLE
`community/steering`: allow/require review from steering members

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -23,3 +23,8 @@ aliases:
   - n-boshnakov
   - RadaBDimitrova
   - rfranzke
+  gardener-technical-steering:
+  - rfranzke
+  - ScheererJ
+  - timebertt
+  - vlerenc

--- a/website/community/steering/OWNERS
+++ b/website/community/steering/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+options:
+  # don't require approval in addition to the steering committee
+  no_parent_owners: true
+
+reviewers:
+- gardener-technical-steering
+approvers:
+- gardener-technical-steering


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

With this PR, steering members are able (and also required) to review/approve changes in the `community/steering` section/directory. It thereby no longer requires a review by the documentation maintainers.

**Which issue(s) this PR fixes**:
See https://github.com/gardener/documentation/pull/937#issuecomment-4260665520

**Special notes for your reviewer**:

/cc @rfranzke @ScheererJ @vlerenc 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established technical steering committee governance structure with designated members assigned as reviewers and approvers for steering directory decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->