### PR TITLE
Added absolute link guidance to Formatting guide

### DIFF
--- a/website/documentation/contribute/documentation/formatting-guide.md
+++ b/website/documentation/contribute/documentation/formatting-guide.md
@@ -105,6 +105,7 @@ Use backticks (\`) for field names, and field values.
 |:---|:---|
 | Use a descriptor of the link's destination: "For more information, visit [Gardener's website](#links-and-references)." | Use a generic placeholder: "For more information, go [here](#links-and-references)." |
 | Use relative links when linking to content in the same repository: `[Style Guide](../style-guide/_index.md)`| Use absolute links when linking to content in the same repository: `[Style Guide](https://github.com/gardener/documentation/blob/master/website/documentation/contribute/documentation/style-guide/_index.md)` |
+| Use GitHub links for absolute links to documentation content: `[Gardener API Server](https://github.com/gardener/gardener/blob/master/docs/usage/shoot_access.md)` | Use website links for documentation content: `[Gardener API Server](https://gardener.cloud/docs/gardener/usage/shoot_access/)` |
 
 Another thing to keep in mind is that markdown links do not work in certain [shortcodes](./shortcodes.md) (e.g., mermaid). To circumvent this problem, you can use HTML links.
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR adds guidance on how to use absolute links in the documentation to the Formatting guide.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated link formatting guidelines to clarify conventions for absolute documentation links, specifying when to use GitHub URLs versus website URLs in documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->