### PR TITLE
Add blog ingress-nginx-retirement-how-gardener-migrated-to-istio

### DIFF
--- a/website/blog/2026/04/04-29-ingress-nginx-retirement-how-gardener-migrated-to-istio.md
+++ b/website/blog/2026/04/04-29-ingress-nginx-retirement-how-gardener-migrated-to-istio.md
@@ -4,10 +4,10 @@ linkTitle: "Ingress NGINX Retirement: How Gardener Migrated to Istio"
 newsSubtitle: April 29, 2026
 publishdate: 2026-04-29
 authors:
-- avatar: https://avatars.githubusercontent.com/rfranzke
-  email: rafael.franzke@sap.com
-  login: rfranzke
-  name: Rafael Franzke
+- avatar: https://avatars.githubusercontent.com/u/30600170?v=4
+  email: johannes.scheerer@sap.com
+  login: ScheererJ
+  name: Johannes Scheerer
 aliases: ["/blog/2026/04/29/ingress-nginx-retirement-how-gardener-migrated-to-istio"]
 ---
 

--- a/website/blog/2026/04/04-29-ingress-nginx-retirement-how-gardener-migrated-to-istio.md
+++ b/website/blog/2026/04/04-29-ingress-nginx-retirement-how-gardener-migrated-to-istio.md
@@ -9,9 +9,14 @@ authors:
   login: ScheererJ
   name: Johannes Scheerer
 aliases: ["/blog/2026/04/29/ingress-nginx-retirement-how-gardener-migrated-to-istio"]
+tags:
+- feature-announcement
+- release-notes
+- networking
+- observability
 ---
 
-With the [retirement of Ingress NGINX](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/) in March 2026, Gardener has completed a full migration of its core components away from Ingress NGINX to Istio's native API — using `VirtualService` and `Gateway` resources for all internal traffic routing.
+The Kubernetes community [retired Ingress NGINX](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/) in March 2026. Gardener has completed a full migration of its core components away from Ingress NGINX to Istio's native API — using `VirtualService` and `Gateway` resources for all incoming traffic routing.
 
 ## Background
 
@@ -35,11 +40,11 @@ In Gardener v1.141, all core components have been migrated:
 
 Basic authentication (previously handled by NGINX auth annotations) is now implemented via a dedicated [external authorization server](https://github.com/gardener/ext-authz-server) that integrates with Envoy's `ext_authz` filter.
 
-The network policy controller in `gardener-resource-manager` was also extended: just as it previously auto-generated network policies for `Ingress` resources, it now does the same for `VirtualService` resources backed by a `Gateway`.
+The network policy controller in `gardener-resource-manager` was also extended: just as it previously auto-generated network policies for `Ingress` resources, it now does the same for `VirtualService` resources backed by a `Gateway`. See the [documentation](https://gardener.cloud/docs/gardener/concepts/resource-manager/#services-exposed-via-istio-virtualservice-resources) for further details.
 
 ## What's Next
 
-Ingress NGINX is still deployed in Gardener landscapes — some extensions still depend on it. A new feature gate allows landscape operators to disable Ingress NGINX once their extensions have migrated. The tracking issue lists remaining work for extension migration.
+Ingress NGINX is still deployed in Gardener landscapes — some extensions still depend on it. Multiple Feature gates will allow landscape operators to disable Ingress NGINX in the garden runtime, seed or shoot clusters once all dependent components have migrated. The [tracking issue (#13448)](https://github.com/gardener/gardener/issues/13448) lists remaining work for extension migration.
 
 For end users, the change is transparent. Observability endpoints are accessible exactly as before, with the same basic authentication flow — only the underlying routing has changed.
 

--- a/website/blog/2026/04/04-29-ingress-nginx-retirement-how-gardener-migrated-to-istio.md
+++ b/website/blog/2026/04/04-29-ingress-nginx-retirement-how-gardener-migrated-to-istio.md
@@ -1,0 +1,49 @@
+---
+title: "Ingress NGINX Retirement: How Gardener Migrated to Istio"
+linkTitle: "Ingress NGINX Retirement: How Gardener Migrated to Istio"
+newsSubtitle: April 29, 2026
+publishdate: 2026-04-29
+authors:
+- avatar: https://avatars.githubusercontent.com/rfranzke
+  email: rafael.franzke@sap.com
+  login: rfranzke
+  name: Rafael Franzke
+aliases: ["/blog/2026/04/29/ingress-nginx-retirement-how-gardener-migrated-to-istio"]
+---
+
+With the [retirement of Ingress NGINX](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/) in March 2026, Gardener has completed a full migration of its core components away from Ingress NGINX to Istio's native API — using `VirtualService` and `Gateway` resources for all internal traffic routing.
+
+## Background
+
+Ingress NGINX was a critical component in Gardener's architecture, used to expose observability tools (Plutono, Prometheus, Alertmanager, Vali), the dashboard, and other services across garden, seed, and shoot control plane namespaces. With upstream support ending, continuing to rely on it meant accepting unpatched security vulnerabilities in a component handling authentication and TLS termination.
+
+## Migration Strategy
+
+Gardener chose to migrate to Istio's native API (`VirtualService`, `Gateway`, `EnvoyFilter`) rather than the Kubernetes Gateway API. The reasoning:
+
+- Istio-native API is already used for exposing `kube-apiserver` in shoot control planes — operators can focus on a single API surface.
+- The Kubernetes Gateway API does not yet cover the full feature set required (e.g., external authorization filters still need Istio-native constructs).
+- Migration to Gateway API can be revisited later without time pressure.
+
+## What Changed
+
+In Gardener v1.141, all core components have been migrated:
+
+- **Garden runtime cluster** — Alertmanager, Gardener Dashboard, discovery server, Plutono, Prometheus (garden + longterm), and Vali now use `VirtualService` resources.
+- **Seed cluster** — Plutono, Prometheus (aggregate), and Vali have been migrated.
+- **Shoot control planes** — Alertmanager, logging/Vali, OpenTelemetry collector, Plutono, and Prometheus all use native Istio exposure.
+
+Basic authentication (previously handled by NGINX auth annotations) is now implemented via a dedicated [external authorization server](https://github.com/gardener/ext-authz-server) that integrates with Envoy's `ext_authz` filter.
+
+The network policy controller in `gardener-resource-manager` was also extended: just as it previously auto-generated network policies for `Ingress` resources, it now does the same for `VirtualService` resources backed by a `Gateway`.
+
+## What's Next
+
+Ingress NGINX is still deployed in Gardener landscapes — some extensions still depend on it. A new feature gate allows landscape operators to disable Ingress NGINX once their extensions have migrated. The tracking issue lists remaining work for extension migration.
+
+For end users, the change is transparent. Observability endpoints are accessible exactly as before, with the same basic authentication flow — only the underlying routing has changed.
+
+## Links
+
+- [Recording (demo starts at 15:56)](https://youtu.be/xUINvwIt9Kk?t=956)
+- [Tracking issue: Ingress NGINX retirement](https://github.com/gardener/gardener/issues/13448)


### PR DESCRIPTION
## Purpose

 This PR proposes a new blog post titled:

> *"Ingress NGINX Retirement: How Gardener Migrated to Istio"*

The purpose of the blog post is to inform the community about new Gardener features or changes (2026-04-29).

## Notes to Reviewers

This blog post was generated with AI assistance from the source material listed below.
Please evaluate whether this topic is suitable for a blog post. If so, review and edit the content as needed.
If you decide the topic isn't appropriate for a blog post, feel free to close this PR and delete the branch.

## Source Material

- https://youtu.be/xUINvwIt9Kk
- https://github.com/gardener/gardener/issues/13448

## Instructions for Reviewers

### ❌ If the blog post isn't viable

- Close this PR
- Delete the branch

### ✏️ If the blog post is viable but requires editing

1. Clone the repository and change to the directory:
```bash
git clone https://github.com/gardener/documentation
cd documentation
```
2. Check out the branch:
```bash
git fetch origin && git checkout blog/2026-04-29-ingress-nginx-retirement-how-gardener-migrated-to-istio
```
3. Review the content in `website/blog/2026/04/04-29-ingress-nginx-retirement-how-gardener-migrated-to-istio.md`.
4. Make any necessary edits, additions, or removals, and then push the changes:
```bash
git add website/blog/2026/04/04-29-ingress-nginx-retirement-how-gardener-migrated-to-istio.md
git commit --amend --no-edit
git push origin +blog/2026-04-29-ingress-nginx-retirement-how-gardener-migrated-to-istio
```

### ✅ If the blog post is ready

- Invite additional reviewers (optional step)
- Comment with `/lgtm` to approve (required step)

The documentation team will review your PR, as required by branch protection.
They will merge it once you (and any additional reviewers) have approved it.

 Thank you for contributing to the Gardener blog!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added blog post documenting Kubernetes Ingress NGINX retirement and system migration to Istio in v1.141.
  * Details API changes, authentication updates, and network policy adjustments for the new routing system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->