### PR TITLE
Add Netlify build plugin to cache docforge API responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,9 @@ dist
 # Docforge binary directory
 /bin
 
+# Docforge HTTP cache (persisted by Netlify plugin between builds)
+.docforge-cache
+
 # vuepress build output
 .vuepress/dist
 

--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ build: ## Build the documentation site
 docforge-ci: docforge-download ## Run docforge in CI mode (non-interactive)
 	@echo "Running docforge (CI)..."
 	@export DOCFORGE_CONFIG=.docforge/config.yaml && \
-	./bin/docforge
+	./bin/docforge --cache-dir ./.docforge-cache
 
 .PHONY: ci-build
 ci-build: docforge-ci install post-process build ## Run all steps for building in CI

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,13 @@
+[build]
+  command = "make ci-build"
+
+[context.deploy-preview]
+  command = "make ci-build"
+
+[[plugins]]
+  package = "./plugins/netlify-plugin-docforge-cache"
+
 [[headers]]
-    for = "/*"
-    [headers.values]
-        X-Frame-Options = "DENY"
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "DENY"

--- a/plugins/netlify-plugin-docforge-cache/index.js
+++ b/plugins/netlify-plugin-docforge-cache/index.js
@@ -1,0 +1,51 @@
+import { readdir } from 'fs/promises';
+import { join } from 'path';
+
+const CACHE_DIR = '.docforge-cache';
+const CACHE_TTL = 86400;
+
+async function collectDigests(dir) {
+  const digests = [];
+  const entries = await readdir(dir, { withFileTypes: true, recursive: true });
+  for (const entry of entries) {
+    if (entry.isFile() && entry.name.endsWith('.yaml')) {
+      digests.push(join(entry.parentPath || entry.path, entry.name));
+    }
+  }
+  return digests;
+}
+
+export const onPreBuild = async function ({ utils }) {
+  if (process.env.CONTEXT === 'production') {
+    console.log('Production build — skipping docforge cache restore (always fresh).');
+    await utils.cache.remove(CACHE_DIR);
+    return;
+  }
+
+  const restored = await utils.cache.restore(CACHE_DIR);
+  if (restored) {
+    console.log('Docforge cache restored from previous build.');
+  } else {
+    console.log('No docforge cache found — will be populated after this build.');
+  }
+};
+
+export const onPostBuild = async function ({ utils }) {
+  if (process.env.CONTEXT === 'production') {
+    console.log('Production build — not saving docforge cache.');
+    return;
+  }
+
+  const digests = await collectDigests('.docforge');
+
+  const saved = await utils.cache.save(CACHE_DIR, {
+    ttl: CACHE_TTL,
+    digests,
+  });
+
+  if (saved) {
+    console.log(`Docforge cache saved (TTL: 24h, tracking ${digests.length} digest files).`);
+  } else {
+    console.log('Docforge cache directory not found — nothing to save.');
+  }
+};

--- a/plugins/netlify-plugin-docforge-cache/index.js
+++ b/plugins/netlify-plugin-docforge-cache/index.js
@@ -4,14 +4,28 @@ import { join } from 'path';
 const CACHE_DIR = '.docforge-cache';
 const CACHE_TTL = 86400;
 
-async function collectDigests(dir) {
+async function collectDigests(baseDir) {
   const digests = [];
-  const entries = await readdir(dir, { withFileTypes: true, recursive: true });
-  for (const entry of entries) {
-    if (entry.isFile() && entry.name.endsWith('.yaml')) {
-      digests.push(join(entry.parentPath || entry.path, entry.name));
+
+  async function walk(dir) {
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch (err) {
+      if (err.code === 'ENOENT') return;
+      throw err;
+    }
+    for (const entry of entries) {
+      const fullPath = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(fullPath);
+      } else if (entry.isFile() && entry.name.endsWith('.yaml')) {
+        digests.push(fullPath);
+      }
     }
   }
+
+  await walk(baseDir);
   return digests;
 }
 

--- a/plugins/netlify-plugin-docforge-cache/index.js
+++ b/plugins/netlify-plugin-docforge-cache/index.js
@@ -31,8 +31,7 @@ async function collectDigests(baseDir) {
 
 export const onPreBuild = async function ({ utils }) {
   if (process.env.CONTEXT === 'production') {
-    console.log('Production build — skipping docforge cache restore (always fresh).');
-    await utils.cache.remove(CACHE_DIR);
+    console.log('Production build — skipping docforge cache (always fresh).');
     return;
   }
 

--- a/plugins/netlify-plugin-docforge-cache/manifest.yml
+++ b/plugins/netlify-plugin-docforge-cache/manifest.yml
@@ -1,0 +1,1 @@
+name: netlify-plugin-docforge-cache


### PR DESCRIPTION
/kind enhancement

**What this PR does / why we need it**:

Deploy preview builds are hitting GitHub API rate limits because docforge fetches documentation content from 35+ repositories on every build. With multiple concurrent deploy previews triggered by PRs, the shared `GITHUB_OAUTH_TOKEN` exhausts its 5,000 requests/hour budget.

This adds a local Netlify build plugin that uses the built-in `utils.cache` utility to persist docforge's HTTP disk cache (`httpcache`/`diskv`) between deploy preview builds. Cached responses use ETags for conditional requests — `304 Not Modified` responses don't count against the rate limit.

**Key behaviors:**
- **Deploy previews**: Cache is restored before build and saved after — drastically reducing API calls
- **Production builds (master)**: Cache is never used — always pulls fresh from GitHub
- **Invalidation on config change**: Cache is invalidated when any `.docforge/**/*.yaml` file changes (via `digests`)
- **Daily expiry**: Cache has a 24-hour TTL so stale content doesn't persist indefinitely

**No changes to docforge itself** — uses the existing `--cache-dir` flag.

**Which issue(s) this PR fixes**:
Fixes GitHub API rate limiting on Netlify deploy previews.

**Special notes for your reviewer**:
- The `build.command` in `netlify.toml` may already be configured via the Netlify dashboard UI — if so, the `[build]` section here will override it
- The plugin is ESM (`import`/`export`) matching the repo's `"type": "module"` in package.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented build caching to improve deployment performance on Netlify.

* **Chores**
  * Updated build configuration and version control settings to support cache management across deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->