### PR TITLE
Remove d suffix from min-release-age in .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-min-release-age=7d
+min-release-age=7


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

`npm` fails for me:
```
make dev       
npx vitepress dev
npm warn invalid config before=null set in ~/documentation/.npmrc
npm warn invalid config Must be one of: null, valid Date string
npm error Invalid time value
npm error A complete log of this run can be found in: ~/.npm/_logs/2026-05-08T07_46_01_143Z-debug-0.log
make: *** [dev] Error 1
```

I'm using `npm@v11` which should support `min-release-age`:
```
npm --version
11.12.1
```

However, it seems to assume days as the unit, so it rejects the `d` suffix.
I am unable to find any documentation with `npm` for this, but it works for me 🤷‍♂️ 

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @klocke-io 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor configuration file update with no user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->