### PR TITLE
Add hackathon tag to relevant blog entries

### DIFF
--- a/hack/apply-blog-tags.mjs
+++ b/hack/apply-blog-tags.mjs
@@ -11,6 +11,7 @@ const CONTENT_TYPE_TAGS = [
   'technical-deep-dive',
   'case-study',
   'community-event',
+  'hackathon',
   'tutorial',
   'milestone'
 ]
@@ -165,6 +166,10 @@ function inferTags(frontmatter, body, filePath) {
 
   if (includesAny(title, ['community meeting', 'kubecon', 'promcon', 'hackathon', 'conference']) || includesAny(slug, ['community-meeting', 'kubecon', 'promcon', 'hackathon'])) {
     tags.push('community-event')
+  }
+
+  if (includesAny(title, ['hackathon']) || includesAny(slug, ['hackathon'])) {
+    tags.push('hackathon')
   }
 
   if (/\bv\d+\.\d+(\.\d+)?\b/.test(title) || includesAny(title, [' release ', 'released'])) {

--- a/website/blog/2024/05/05-21-innovation-unleashed-a-deep-dive-into-the-5th-gardener-community-hackathon.md
+++ b/website/blog/2024/05/05-21-innovation-unleashed-a-deep-dive-into-the-5th-gardener-community-hackathon.md
@@ -13,6 +13,7 @@ tags:
   - community-event
   - security
   - helm
+  - hackathon
 ---
 ![Hackathon 2024/05 Team](images/hackathon202405-team.jpg "Hackathon 2024/05 Team")
 

--- a/website/blog/2024/12/12-08-unleashing-potential-highlights-from-the-6th-gardener-community-hackathon.md
+++ b/website/blog/2024/12/12-08-unleashing-potential-highlights-from-the-6th-gardener-community-hackathon.md
@@ -12,6 +12,7 @@ tags:
   - feature-announcement
   - community-event
   - networking
+  - hackathon
 ---
 ![Hackathon 2024/12 Team](images/hackathon202412-team.jpg "Hackathon 2024/12 Team")
 

--- a/website/blog/2025/06/06-17-taking-gardener-to-the-next-level-highlights-from-the-7th-gardener-community-hackathon-in-schelklingen.md
+++ b/website/blog/2025/06/06-17-taking-gardener-to-the-next-level-highlights-from-the-7th-gardener-community-hackathon-in-schelklingen.md
@@ -11,6 +11,7 @@ aliases: ["/blog/2025/06/06-17-taking-gardener-to-the-next-level-highlights-from
 tags:
   - community-event
   - apeiro
+  - hackathon
 ---
 # Taking Gardener to the Next Level: Highlights from the 7th Gardener Community Hackathon in Schelklingen
 

--- a/website/documentation/contribute/documentation/blog-tags.md
+++ b/website/documentation/contribute/documentation/blog-tags.md
@@ -17,6 +17,7 @@ Use lowercase kebab-case (`tag-name`) for all tags.
 - `technical-deep-dive`: Detailed technical analysis and architecture content.
 - `case-study`: Practical implementation reports and production stories.
 - `community-event`: Community meeting, conference or Hackathon updates.
+- `hackathon`: Hackathon updates.
 - `tutorial`: Step-by-step usage guidance.
 - `milestone`: Project anniversary or major achievement summaries.
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement discussion

**What this PR does / why we need it**:

I'd like to add a new `hackathon` tag to relevant blog entries. I like that the broader `community-event`tag includes other activities as well, but I'd also like to have a specific tag to easily find all hackathon entries.

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @n-boshnakov 

I hope I added the new tag to all relevant places 🤞 