### PR TITLE
Updated image rendering in Hack The Garden 05/2026 Wrap Up post

### DIFF
--- a/website/community/hackathons/2026-05.md
+++ b/website/community/hackathons/2026-05.md
@@ -12,10 +12,10 @@ outline: 2
 - 📘 **Topics:** [hackathon#72](https://github.com/gardener/hackathon/discussions/72)
 - 🎤 **Review Meeting Summary:** https://gardener.cloud/community/review-meetings/2026-reviews/#_2026-05-13-hack-the-garden-wrap-up
 
-<p float="left">
-  <img src="./images/2026-05_1.png" width="49%" />
-  <img src="./images/2026-05_2.jpg" width="49%" />
-</p>
+<div style="display: flex; justify-content: center; gap: 20px; margin: 24px 0;">
+  <img src="./images/2026-05_1.png" style="width: 49%; max-width: 100%;" />
+  <img src="./images/2026-05_2.jpg" style="width: 49%; max-width: 100%;" />
+</div>
 
 ## 🌱 Complete the `ManagedSeedSet` Implementation ([#52](https://github.com/gardener/hackathon/issues/52))
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR fixes an issue with the rendering of the images in [Hack The Garden 05/2026 Wrap Up](https://gardener.cloud/community/hackathons/2026-05/).

**Which issue(s) this PR fixes**:
Fixes #966 

**Special notes for your reviewer**:
Final rendering:
<img width="1770" height="1202" alt="image" src="https://github.com/user-attachments/assets/b321518a-9134-478d-920f-b5da6f03ef1b" />
