### PR TITLE
Fix: Add aliases for old /docs/contribute/ URLs

### DIFF
--- a/website/contribute/contribution-process/contributing-bigger-changes.md
+++ b/website/contribute/contribution-process/contributing-bigger-changes.md
@@ -3,6 +3,7 @@ title: Contributing Bigger Changes
 sidebar: true
 menu: sln
 weight: 20
+aliases: ["/docs/contribute/code/contributing-bigger-changes/"]
 ---
 
 ## Contributing Bigger Changes

--- a/website/contribute/contribution-process/contributor-guide.md
+++ b/website/contribute/contribution-process/contributor-guide.md
@@ -2,6 +2,7 @@
 title: Contributor Guide
 persona: Developers
 weight: 10
+aliases: ["/docs/contribute/", "/docs/contribute/code/"]
 ---
 
 Thank you for your interest in contributing to Gardener. This page provides an overview of how to get started, what to expect from the contribution process, and how to connect with the community.

--- a/website/contribute/contribution-process/roles.md
+++ b/website/contribute/contribution-process/roles.md
@@ -2,6 +2,7 @@
 title: Community Roles
 weight: 30
 outline: 2
+aliases: ["/docs/contribute/code/roles/"]
 ---
 
 # Community Roles

--- a/website/contribute/documentation/_index.md
+++ b/website/contribute/documentation/_index.md
@@ -2,4 +2,5 @@
 title: Documentation
 url: /contribute/documentation/
 weight: 70
+aliases: ["/contribute/docs/", "/docs/contribute/documentation/"]
 ---

--- a/website/contribute/documentation/adding-existing-documentation.md
+++ b/website/contribute/documentation/adding-existing-documentation.md
@@ -1,5 +1,6 @@
 ---
 title: Adding Already Existing Documentation
+aliases: ["/docs/contribute/documentation/adding-existing-documentation/"]
 ---
 
 ## Overview

--- a/website/contribute/documentation/blog-tags.md
+++ b/website/contribute/documentation/blog-tags.md
@@ -1,5 +1,6 @@
 ---
 title: Blog Tags Reference
+aliases: ["/docs/contribute/documentation/blog-tags/"]
 ---
 
 ## Overview

--- a/website/contribute/documentation/formatting-guide.md
+++ b/website/contribute/documentation/formatting-guide.md
@@ -1,5 +1,6 @@
 ---
 title: Formatting Guide
+aliases: ["/docs/contribute/documentation/formatting-guide/"]
 ---
 
 This page gives writing formatting guidelines for the Gardener documentation. For style guidelines, see the [Style Guide](./style-guide/_index.md).

--- a/website/contribute/documentation/images.md
+++ b/website/contribute/documentation/images.md
@@ -1,6 +1,6 @@
 ---
 title: Working with Images
-aliases: ["/docs/guides/contributors/content/images"]
+aliases: ["/docs/guides/contributors/content/images", "/docs/contribute/documentation/images/"]
 weight: 15
 ---
 

--- a/website/contribute/documentation/markup.md
+++ b/website/contribute/documentation/markup.md
@@ -1,5 +1,6 @@
 ---
 title: Markdown
+aliases: ["/docs/contribute/documentation/markup/"]
 ---
 
 Hugo uses [Markdown](https://www.markdownguide.org/) for its simple content format. However, there are a lot of things that Markdown doesn't support well. You could use pure HTML to expand possibilities. A typical example is reducing the original dimensions of an image.

--- a/website/contribute/documentation/organization.md
+++ b/website/contribute/documentation/organization.md
@@ -1,5 +1,6 @@
 ---
 title: Organization
+aliases: ["/docs/contribute/documentation/organization/"]
 ---
 
 The Gardener project implements the *documentation-as-code* paradigm. Essentially this means that:

--- a/website/contribute/documentation/pr-guidelines.md
+++ b/website/contribute/documentation/pr-guidelines.md
@@ -1,6 +1,6 @@
 ---
 title: Pull Request Creation Guidelines
-aliases: ["/docs/contribute/documentation/pr-description"]
+aliases: ["/docs/contribute/documentation/pr-description", "/docs/contribute/documentation/pr-guidelines/"]
 ---
 
 <!-- contains only public information -->

--- a/website/contribute/documentation/shortcodes.md
+++ b/website/contribute/documentation/shortcodes.md
@@ -1,5 +1,6 @@
 ---
 title: Shortcodes
+aliases: ["/docs/contribute/documentation/shortcodes/"]
 ---
 
 Shortcodes are the Hugo way to extend the limitations of Markdown before resorting to HTML. There are a number of built-in shortcodes available from Hugo. This list is extended with Gardener website shortcodes designed specifically for its content.

--- a/website/contribute/documentation/style-guide/_index.md
+++ b/website/contribute/documentation/style-guide/_index.md
@@ -1,5 +1,6 @@
 ---
 Title: Style Guide
+aliases: ["/docs/contribute/documentation/style-guide/"]
 ---
 This page gives writing style guidelines for the Gardener documentation. For formatting guidelines, see the [Formatting Guide](../formatting-guide.md).
 

--- a/website/contribute/documentation/style-guide/concept_template.md
+++ b/website/contribute/documentation/style-guide/concept_template.md
@@ -1,6 +1,7 @@
 ---
 Title: Concept Topic Structure
 Description: Describes the contents of a concept topic
+aliases: ["/docs/contribute/documentation/style-guide/concept_template/"]
 ---
 
 # Concept Title

--- a/website/contribute/documentation/style-guide/reference_template.md
+++ b/website/contribute/documentation/style-guide/reference_template.md
@@ -1,6 +1,7 @@
 ---
 Title: Reference Topic Structure
 Description: Describes the contents of a reference topic
+aliases: ["/docs/contribute/documentation/style-guide/reference_template/"]
 ---
 
 # Topic Title

--- a/website/contribute/documentation/style-guide/task_template.md
+++ b/website/contribute/documentation/style-guide/task_template.md
@@ -1,6 +1,7 @@
 ---
 Title: Task Topic Structure
 Description: Describes the contents of a task topic
+aliases: ["/docs/contribute/documentation/style-guide/task_template/"]
 ---
 
 # Task Title


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
The Contribute section was moved from `/docs/contribute/` to `/contribute/` in [#956](https://github.com/gardener/documentation/pull/956). The current PR adds aliases to all affected pages so that existing external links (e.g. from other Gardener repositories) continue to work.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
