### PR TITLE
Fix Helm chart deprecation notice in dashboard 1.84.0 blog

### DIFF
--- a/website/blog/2026/05/05-11-gardener-dashboard-1840.md
+++ b/website/blog/2026/05/05-11-gardener-dashboard-1840.md
@@ -41,7 +41,7 @@ The dashboard now uses the new `credentialsRef` / `credentials` keys for DNS pro
 
 ## Helm Chart Deprecation Notice
 
-The `gardener-dashboard` and `identity` Helm charts are **deprecated** in favor of `gardener-operator` managed deployments. These charts will be removed earliest around November 2026. If you still rely on Helm-based dashboard installations, please plan your migration to `gardener-operator` — see the [migration guide](https://github.com/gardener/gardener/blob/master/docs/concepts/operator.md#migrating-an-existing-gardener-landscape-to-gardener-operator).
+The `gardener-dashboard` Helm chart is **deprecated** in favor of `gardener-operator` managed deployments. The `identity` Helm chart is **deprecated without replacement**. Both charts will be removed earliest around November 2026. If you still rely on Helm-based dashboard installations, please plan your migration to `gardener-operator` — see the [migration guide](https://github.com/gardener/gardener/blob/master/docs/concepts/operator.md#migrating-an-existing-gardener-landscape-to-gardener-operator).
 
 ## Links
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

/kind cleanup

**What this PR does / why we need it**:

Corrects the Helm Chart Deprecation Notice section to distinguish between the two deprecation cases:
- `gardener-dashboard` chart: deprecated in favor of `gardener-operator` (gardener/dashboard#2935)
- `identity` chart: deprecated without replacement (gardener/dashboard#2963)

**Which issue(s) this PR fixes**:

Follow-up to https://github.com/gardener/documentation/pull/963

**Special notes for your reviewer**: