### PR TITLE
Fix `readme` path artifacts in docforge-generated proposal links

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -10,6 +10,7 @@ import { hasMarkdownContent, getTaxonomyChildren } from './theme/utils/sidebar.t
 import { generateAliasRedirects, createAliasRedirectDevPlugin } from './plugins/alias-redirects';
 
 const indexPattern = new RegExp(/\/?_?index\.md$/i);
+const readmePattern = new RegExp(/\/?readme\.md$/i);
 const siteBase = process.env.VITE_PUBLIC_BASE_PATH || ''
 const siteSrcDir = 'hugo/content'
 
@@ -57,6 +58,9 @@ export default defineConfig({
     hostname: 'https://gardener.cloud'
   },
   rewrites(id) {
+    if (readmePattern.test(id)) {
+      return id.replace(readmePattern, '/index.md').replace(/^\//, '');
+    }
     if (!indexPattern.test(id) && id.endsWith('.md')) {
       return id.slice(0, -3) + '/index.md';
     }

--- a/post-processing/part-index.js
+++ b/post-processing/part-index.js
@@ -48,6 +48,18 @@ function main() {
 
       fs.copyFileSync(file, destinationFile);
       console.log(`Copied ${file} to ${destinationFile}`);
+
+      // Fix /path/readme/ links that docforge generates when it rewrites links
+      // in README.md files before renaming them to _index.md. Two cases:
+      //   1. Self-referential ToC:  (/path/readme/#anchor) → (#anchor)
+      //   2. Cross-proposal links:  (/path/readme/)        → (/path/)
+      let content = fs.readFileSync(destinationFile, 'utf8');
+      let fixed = content.replace(/\(([^)]*?)\/readme\/(#[^)]*)\)/gi, '($2)');
+      fixed = fixed.replace(/\(([^)]*?)\/readme\/\)/gi, '($1/)');
+      if (fixed !== content) {
+        fs.writeFileSync(destinationFile, fixed, 'utf8');
+        console.log(`  Fixed readme links in ${destinationFile}`);
+      }
     }
 
     console.log(`Processed ${indexFiles.length} files`);


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR:
- Added a readmePattern guard to the VitePress rewrites() function in .vitepress/config.mts so README.md files are treated as directory index pages instead of being nested under a spurious /readme/ subdirectory. 
- Extended post-processing/part-index.js to rewrite two categories of broken links docforge generates: self-referential ToC anchors (/path/readme/#anchor → #anchor) and cross-proposal links (/path/readme/ → /path/). 
- Both fixes are general and apply automatically to all current and future GEPs - 34 proposal pages were fixed in this run with no impact on committed source files.

**Which issue(s) this PR fixes**:
Fixes #971 

**Special notes for your reviewer**:
Opening a ToC link:
<img width="1728" height="861" alt="image" src="https://github.com/user-attachments/assets/bf7e410d-7265-48c1-936a-3b57245261af" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed broken documentation links that occur when README files are converted to documentation pages
  * Improved path routing and internal link handling for README-based documentation to ensure correct display

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gardener/documentation/pull/972)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->