### PR TITLE
chore: ignore .worktrees and worktrees directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *~
 .idea
+.worktrees
+worktrees
 hugo/public
 node_modules
 hugo/resources/_gen


### PR DESCRIPTION
**How to categorize this PR?**

/kind cleanup

**What this PR does / why we need it**:

Adds `.worktrees/` and `worktrees/` to `.gitignore` so local git worktrees do not surface as untracked files.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ignore patterns for internal development workflows.

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->