### PR TITLE
Removed Provider Equinix Metal due to sunset

### DIFF
--- a/.docforge/documentation/gardener-extensions/infrastructure.yaml
+++ b/.docforge/documentation/gardener-extensions/infrastructure.yaml
@@ -53,14 +53,6 @@ structure:
   - fileTree: https://github.com/gardener/gardener-extension-provider-openstack/tree/master/docs
     excludeFiles:
       - "development/"
-- dir: gardener-extension-provider-equinix-metal
-  structure:
-  - file: _index.md
-    frontmatter:
-      title: Provider Equinix Metal
-      description: Gardener extension controller for the Equinix Metal cloud provider
-    source:  https://github.com/gardener/gardener-extension-provider-equinix-metal/blob/master/README.md
-  - fileTree: https://github.com/gardener/gardener-extension-provider-equinix-metal/tree/master/docs
 - dir: gardener-extension-provider-stackit
   structure:
   - file: _index.md


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR removes the Equinix Metal service provider from the website due to it becoming sunset.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Information for sunset (end of June 2026):
https://github.com/gardener/gardener-extension-provider-equinix-metal#equinix-metal-sunset
https://github.com/gardener/gardener-extension-provider-equinix-metal/pull/453#issuecomment-4727984609
