### PR TITLE
Reorder supported infrastructures on landing page

### DIFF
--- a/website/index.md
+++ b/website/index.md
@@ -67,8 +67,21 @@ import ThemedTeamMembers from '@components/ThemedTeamMembers.vue'
 
 const members = [
   {
-    name: 'Alibaba Cloud',
-    logo: '/lp/platforms/alibaba-cloud.svg'
+    name: 'OpenStack',
+    logo: '/lp/platforms/openstack.svg'
+  },
+  {
+    name: 'Metal-Stack',
+    logo: '/lp/platforms/metalstack.svg'
+  },
+  {
+    name: 'Iron Core',
+    logo: '/lp/platforms/iron_core.svg'
+  },
+  {
+    name: 'STACKIT',
+    logo: '/lp/platforms/stackit.svg',
+    darkLogo: '/lp/platforms/stackit-dark.svg'
   },
   {
     name: 'Amazon Web Services',
@@ -84,21 +97,8 @@ const members = [
     logo: '/lp/platforms/google-cloud-platform.svg',
   },
   {
-    name: 'Metal-Stack',
-    logo: '/lp/platforms/metalstack.svg'
-  },
-  {
-    name: 'OpenStack',
-    logo: '/lp/platforms/openstack.svg'
-  },
-  {
-    name: 'Iron Core',
-    logo: '/lp/platforms/iron_core.svg'
-  },
-  {
-    name: 'STACKIT',
-    logo: '/lp/platforms/stackit.svg',
-    darkLogo: '/lp/platforms/stackit-dark.svg'
+    name: 'Alibaba Cloud',
+    logo: '/lp/platforms/alibaba-cloud.svg'
   },
 ]
 </script>

--- a/website/index.md
+++ b/website/index.md
@@ -71,11 +71,11 @@ const members = [
     logo: '/lp/platforms/openstack.svg'
   },
   {
-    name: 'Metal-Stack',
+    name: 'metal-stack',
     logo: '/lp/platforms/metalstack.svg'
   },
   {
-    name: 'Iron Core',
+    name: 'IronCore',
     logo: '/lp/platforms/iron_core.svg'
   },
   {
@@ -93,7 +93,7 @@ const members = [
     logo: '/lp/platforms/microsoft-azure.svg'
   },
   {
-    name: 'Google Cloud Platform',
+    name: 'Google Cloud',
     logo: '/lp/platforms/google-cloud-platform.svg',
   },
   {

--- a/website/index.md
+++ b/website/index.md
@@ -92,10 +92,6 @@ const members = [
     logo: '/lp/platforms/openstack.svg'
   },
   {
-    name: 'SAP Data Center',
-    logo: '/lp/platforms/sap.svg'
-  },
-  {
     name: 'Iron Core',
     logo: '/lp/platforms/iron_core.svg'
   },


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind task

**What this PR does / why we need it**:
The PR reorders the landing-page cards for the supported infrastructures:

- Removes *SAP Data Center*
- Moves *OpenStack* and bare metal offerings to the front
- Moves *Alibaba Cloud* to the end
- Fixes spelling/formatting issues in the names

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/documentation/issues/832

**Special notes for your reviewer**:
/cc @marc1404 
