### PR TITLE
Add Vale rule for detecting unescaped angle brackets

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -8,7 +8,7 @@ IgnoredScopes = code, tt, code block
 [*.md]
 BasedOnStyles = Gardener
 
-TokenIgnores = (`[^`]+`), (<[^>]+>), (v[0-9]+(?:\.[0-9]+)*(?:alpha[0-9]+|beta[0-9]+)?), (/[^\s]+), (https?://\S+), ([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]+), (\w+\(s\)), (\*+\w+\**|\w+\*+)
+TokenIgnores = (`[^`]+`), (v[0-9]+(?:\.[0-9]+)*(?:alpha[0-9]+|beta[0-9]+)?), (/[^\s]+), (https?://\S+), ([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]+), (\w+\(s\)), (\*+\w+\**|\w+\*+)
 
 BlockIgnores = (?s)(\{\{.*?\}\})
 

--- a/.vale/styles/Gardener/AngleBrackets.yml
+++ b/.vale/styles/Gardener/AngleBrackets.yml
@@ -1,0 +1,5 @@
+extends: existence
+message: "'%s' looks like an unescaped placeholder or unknown HTML tag. Wrap it in backticks if it's a placeholder (e.g. `<pod-name>`), or add it to the allowed tags list in AngleBrackets.yml if it's a valid HTML tag."
+level: error
+tokens:
+  - '<(?!\/?(?:a|abbr|address|area|article|aside|audio|b|base|bdi|bdo|blockquote|body|br|button|canvas|caption|cite|code|col|colgroup|data|datalist|dd|del|details|dfn|dialog|div|dl|dt|em|embed|fencedframe|fieldset|figcaption|figure|footer|form|h1|h2|h3|h4|h5|h6|head|header|hgroup|hr|html|i|iframe|img|input|ins|kbd|label|legend|li|link|main|map|mark|math|menu|meta|meter|nav|noscript|object|ol|optgroup|option|output|p|param|picture|pre|progress|q|rp|rt|ruby|s|samp|script|search|section|select|slot|small|source|span|strong|style|sub|summary|sup|svg|table|tbody|td|template|textarea|tfoot|th|thead|time|title|tr|track|u|ul|var|video|wbr)(?:\s|>|\/))[A-Za-z][\w\s._\-|]*>'

--- a/.vale/styles/Gardener/AngleBrackets.yml
+++ b/.vale/styles/Gardener/AngleBrackets.yml
@@ -1,5 +1,5 @@
 extends: script
-message: "'%s' looks like an unescaped placeholder or unknown HTML tag. Wrap it in backticks if it's a placeholder (e.g., `<placeholder>`), or add it to the allowed tags list in AngleBrackets.yml if it's a valid HTML tag."
+message: "'%s' looks like an unescaped placeholder or unknown HTML tag. Wrap it in backticks if it's a placeholder (e.g., `<placeholder>`), or add it to the allowed tags list in `.vale/styles/config/scripts/AngleBrackets.tengo` if it's a valid HTML tag."
 level: error
 scope: raw
 script: AngleBrackets.tengo

--- a/.vale/styles/Gardener/AngleBrackets.yml
+++ b/.vale/styles/Gardener/AngleBrackets.yml
@@ -1,5 +1,5 @@
 extends: script
-message: "'%s' looks like an unescaped placeholder or unknown HTML tag. Wrap it in backticks if it's a placeholder (e.g. `<placeholder>`), or add it to the allowed tags list in AngleBrackets.yml if it's a valid HTML tag."
+message: "'%s' looks like an unescaped placeholder or unknown HTML tag. Wrap it in backticks if it's a placeholder (e.g., `<placeholder>`), or add it to the allowed tags list in AngleBrackets.yml if it's a valid HTML tag."
 level: error
 scope: raw
 script: AngleBrackets.tengo

--- a/.vale/styles/Gardener/AngleBrackets.yml
+++ b/.vale/styles/Gardener/AngleBrackets.yml
@@ -1,5 +1,7 @@
 extends: existence
 message: "'%s' looks like an unescaped placeholder or unknown HTML tag. Wrap it in backticks if it's a placeholder (e.g. `<pod-name>`), or add it to the allowed tags list in AngleBrackets.yml if it's a valid HTML tag."
 level: error
+scope: raw
+nonword: true
 tokens:
-  - '<(?!\/?(?:a|abbr|address|area|article|aside|audio|b|base|bdi|bdo|blockquote|body|br|button|canvas|caption|cite|code|col|colgroup|data|datalist|dd|del|details|dfn|dialog|div|dl|dt|em|embed|fencedframe|fieldset|figcaption|figure|footer|form|h1|h2|h3|h4|h5|h6|head|header|hgroup|hr|html|i|iframe|img|input|ins|kbd|label|legend|li|link|main|map|mark|math|menu|meta|meter|nav|noscript|object|ol|optgroup|option|output|p|param|picture|pre|progress|q|rp|rt|ruby|s|samp|script|search|section|select|slot|small|source|span|strong|style|sub|summary|sup|svg|table|tbody|td|template|textarea|tfoot|th|thead|time|title|tr|track|u|ul|var|video|wbr)(?:\s|>|\/))[A-Za-z][\w\s._\-|]*>'
+  - '(?<!`)<(?!\/?(?:a|abbr|address|area|article|aside|audio|b|base|bdi|bdo|blockquote|body|br|button|canvas|caption|cite|code|col|colgroup|data|datalist|dd|del|details|dfn|dialog|div|dl|dt|em|embed|fencedframe|fieldset|figcaption|figure|footer|form|h1|h2|h3|h4|h5|h6|head|header|hgroup|hr|html|i|iframe|img|input|ins|kbd|label|legend|li|link|main|map|mark|math|menu|meta|meter|nav|noscript|object|ol|optgroup|option|output|p|param|picture|pre|progress|q|rp|rt|ruby|s|samp|script|search|section|select|slot|small|source|span|strong|style|sub|summary|sup|svg|table|tbody|td|template|textarea|tfoot|th|thead|time|title|tr|track|u|ul|var|video|wbr)(?:\s|>|\/))[A-Za-z][\w\s._\-|]*>(?!`)'

--- a/.vale/styles/Gardener/AngleBrackets.yml
+++ b/.vale/styles/Gardener/AngleBrackets.yml
@@ -1,7 +1,5 @@
-extends: existence
+extends: script
 message: "'%s' looks like an unescaped placeholder or unknown HTML tag. Wrap it in backticks if it's a placeholder (e.g. `<pod-name>`), or add it to the allowed tags list in AngleBrackets.yml if it's a valid HTML tag."
 level: error
 scope: raw
-nonword: true
-tokens:
-  - '(?<!`)<(?!\/?(?:a|abbr|address|area|article|aside|audio|b|base|bdi|bdo|blockquote|body|br|button|canvas|caption|cite|code|col|colgroup|data|datalist|dd|del|details|dfn|dialog|div|dl|dt|em|embed|fencedframe|fieldset|figcaption|figure|footer|form|h1|h2|h3|h4|h5|h6|head|header|hgroup|hr|html|i|iframe|img|input|ins|kbd|label|legend|li|link|main|map|mark|math|menu|meta|meter|nav|noscript|object|ol|optgroup|option|output|p|param|picture|pre|progress|q|rp|rt|ruby|s|samp|script|search|section|select|slot|small|source|span|strong|style|sub|summary|sup|svg|table|tbody|td|template|textarea|tfoot|th|thead|time|title|tr|track|u|ul|var|video|wbr)(?:\s|>|\/))[A-Za-z][\w\s._\-|]*>(?!`)'
+script: AngleBrackets.tengo

--- a/.vale/styles/Gardener/AngleBrackets.yml
+++ b/.vale/styles/Gardener/AngleBrackets.yml
@@ -1,5 +1,5 @@
 extends: script
-message: "'%s' looks like an unescaped placeholder or unknown HTML tag. Wrap it in backticks if it's a placeholder (e.g. `<pod-name>`), or add it to the allowed tags list in AngleBrackets.yml if it's a valid HTML tag."
+message: "'%s' looks like an unescaped placeholder or unknown HTML tag. Wrap it in backticks if it's a placeholder (e.g. `<placeholder>`), or add it to the allowed tags list in AngleBrackets.yml if it's a valid HTML tag."
 level: error
 scope: raw
 script: AngleBrackets.tengo

--- a/.vale/styles/config/scripts/AngleBrackets.tengo
+++ b/.vale/styles/config/scripts/AngleBrackets.tengo
@@ -1,0 +1,41 @@
+text := import("text")
+
+matches := []
+
+// Strip fenced code blocks so placeholders inside them are not flagged
+stripped := text.re_replace("(?s)```[^`][^`][^`].*?```", scope, "")
+
+// Strip inline backtick spans so `<pod-name>` is not flagged
+stripped = text.re_replace("`[^`]+`", stripped, "")
+
+// Match any <word> or <multi word> pattern (Go RE2 - no lookaheads)
+found := text.re_find("<[A-Za-z][\\w\\s._\\-|]*>", stripped, -1)
+if !is_undefined(found) {
+    search_from := 0
+    for group in found {
+        m := group[0]
+        tag := text.to_lower(text.trim(m.text, "<>"))
+        tag_name := text.split(tag, " ")[0]
+
+        // Skip known HTML5 tags
+        html_tags := ["a","abbr","address","area","article","aside","audio","b","base","bdi","bdo","blockquote","body","br","button","canvas","caption","cite","code","col","colgroup","data","datalist","dd","del","details","dfn","dialog","div","dl","dt","em","embed","fencedframe","fieldset","figcaption","figure","footer","form","h1","h2","h3","h4","h5","h6","head","header","hgroup","hr","html","i","iframe","img","input","ins","kbd","label","legend","li","link","main","map","mark","math","menu","meta","meter","nav","noscript","object","ol","optgroup","option","output","p","param","picture","pre","progress","q","rp","rt","ruby","s","samp","script","search","section","select","slot","small","source","span","strong","style","sub","summary","sup","svg","table","tbody","td","template","textarea","tfoot","th","thead","time","title","tr","track","u","ul","var","video","wbr"]
+        is_html := false
+        for t in html_tags {
+            if tag_name == t {
+                is_html = true
+                break
+            }
+        }
+
+        if !is_html {
+            // Find this match in the original scope, starting from search_from
+            // to correctly handle duplicate placeholder text
+            pos := text.index(scope[search_from:], m.text)
+            if pos >= 0 {
+                abs_pos := search_from + pos
+                matches = append(matches, {begin: abs_pos, end: abs_pos + len(m.text)})
+                search_from = abs_pos + len(m.text)
+            }
+        }
+    }
+}

--- a/.vale/styles/config/scripts/AngleBrackets.tengo
+++ b/.vale/styles/config/scripts/AngleBrackets.tengo
@@ -5,6 +5,9 @@ matches := []
 // Strip fenced code blocks so placeholders inside them are not flagged
 stripped := text.re_replace("(?s)```[^`][^`][^`].*?```", scope, "")
 
+// Strip <code>...</code> blocks
+stripped = text.re_replace("(?s)<code>.*?</code>", stripped, "")
+
 // Strip inline backtick spans so `<pod-name>` is not flagged
 stripped = text.re_replace("`[^`]+`", stripped, "")
 

--- a/.vale/styles/config/scripts/AngleBrackets.tengo
+++ b/.vale/styles/config/scripts/AngleBrackets.tengo
@@ -21,16 +21,34 @@ if !is_undefined(found) {
         tag_name := text.split(tag, " ")[0]
 
         // Skip known HTML5 tags
-        html_tags := ["a","abbr","address","area","article","aside","audio","b","base","bdi","bdo","blockquote","body","br","button","canvas","caption","cite","code","col","colgroup","data","datalist","dd","del","details","dfn","dialog","div","dl","dt","em","embed","fencedframe","fieldset","figcaption","figure","footer","form","h1","h2","h3","h4","h5","h6","head","header","hgroup","hr","html","i","iframe","img","input","ins","kbd","label","legend","li","link","main","map","mark","math","menu","meta","meter","nav","noscript","object","ol","optgroup","option","output","p","param","picture","pre","progress","q","rp","rt","ruby","s","samp","script","search","section","select","slot","small","source","span","strong","style","sub","summary","sup","svg","table","tbody","td","template","textarea","tfoot","th","thead","time","title","tr","track","u","ul","var","video","wbr"]
-        is_html := false
-        for t in html_tags {
-            if tag_name == t {
-                is_html = true
-                break
-            }
+        html_tags := {
+            "a": true, "abbr": true, "address": true, "area": true, "article": true,
+            "aside": true, "audio": true, "b": true, "base": true, "bdi": true,
+            "bdo": true, "blockquote": true, "body": true, "br": true, "button": true,
+            "canvas": true, "caption": true, "cite": true, "code": true, "col": true,
+            "colgroup": true, "data": true, "datalist": true, "dd": true, "del": true,
+            "details": true, "dfn": true, "dialog": true, "div": true, "dl": true,
+            "dt": true, "em": true, "embed": true, "fencedframe": true, "fieldset": true,
+            "figcaption": true, "figure": true, "footer": true, "form": true,
+            "h1": true, "h2": true, "h3": true, "h4": true, "h5": true, "h6": true,
+            "head": true, "header": true, "hgroup": true, "hr": true, "html": true,
+            "i": true, "iframe": true, "img": true, "input": true, "ins": true,
+            "kbd": true, "label": true, "legend": true, "li": true, "link": true,
+            "main": true, "map": true, "mark": true, "math": true, "menu": true,
+            "meta": true, "meter": true, "nav": true, "noscript": true, "object": true,
+            "ol": true, "optgroup": true, "option": true, "output": true, "p": true,
+            "param": true, "picture": true, "pre": true, "progress": true,
+            "q": true, "rp": true, "rt": true, "ruby": true,
+            "s": true, "samp": true, "script": true, "search": true, "section": true,
+            "select": true, "slot": true, "small": true, "source": true, "span": true,
+            "strong": true, "style": true, "sub": true, "summary": true, "sup": true,
+            "svg": true, "table": true, "tbody": true, "td": true, "template": true,
+            "textarea": true, "tfoot": true, "th": true, "thead": true, "time": true,
+            "title": true, "tr": true, "track": true,
+            "u": true, "ul": true, "var": true, "video": true, "wbr": true
         }
 
-        if !is_html {
+        if !html_tags[tag_name] {
             // Find this match in the original scope, starting from search_from
             // to correctly handle duplicate placeholder text
             pos := text.index(scope[search_from:], m.text)

--- a/.vale/styles/config/scripts/AngleBrackets.tengo
+++ b/.vale/styles/config/scripts/AngleBrackets.tengo
@@ -2,60 +2,78 @@ text := import("text")
 
 matches := []
 
-// Strip fenced code blocks so placeholders inside them are not flagged
-stripped := text.re_replace("(?s)```[^`][^`][^`].*?```", scope, "")
+// Collect all ranges to ignore: fenced code blocks, <code> blocks, inline backtick spans
+ignored := []
 
-// Strip <code>...</code> blocks
-stripped = text.re_replace("(?s)<code>.*?</code>", stripped, "")
+fence_found := text.re_find("(?s)```.*?```", scope, -1)
+if !is_undefined(fence_found) {
+    for g in fence_found {
+        ignored = append(ignored, {s: g[0].begin, e: g[0].end})
+    }
+}
 
-// Strip inline backtick spans so `<pod-name>` is not flagged
-stripped = text.re_replace("`[^`]+`", stripped, "")
+code_found := text.re_find("(?s)<code>.*?</code>", scope, -1)
+if !is_undefined(code_found) {
+    for g in code_found {
+        ignored = append(ignored, {s: g[0].begin, e: g[0].end})
+    }
+}
 
-// Match any <word> or <multi word> pattern (Go RE2 - no lookaheads)
-found := text.re_find("<[A-Za-z][\\w\\s._\\-|]*>", stripped, -1)
+bt_found := text.re_find("`[^`]+`", scope, -1)
+if !is_undefined(bt_found) {
+    for g in bt_found {
+        ignored = append(ignored, {s: g[0].begin, e: g[0].end})
+    }
+}
+
+// Known HTML5 tags - defined once for efficiency
+html_tags := {
+    "a": true, "abbr": true, "address": true, "area": true, "article": true,
+    "aside": true, "audio": true, "b": true, "base": true, "bdi": true,
+    "bdo": true, "blockquote": true, "body": true, "br": true, "button": true,
+    "canvas": true, "caption": true, "cite": true, "code": true, "col": true,
+    "colgroup": true, "data": true, "datalist": true, "dd": true, "del": true,
+    "details": true, "dfn": true, "dialog": true, "div": true, "dl": true,
+    "dt": true, "em": true, "embed": true, "fencedframe": true, "fieldset": true,
+    "figcaption": true, "figure": true, "footer": true, "form": true,
+    "h1": true, "h2": true, "h3": true, "h4": true, "h5": true, "h6": true,
+    "head": true, "header": true, "hgroup": true, "hr": true, "html": true,
+    "i": true, "iframe": true, "img": true, "input": true, "ins": true,
+    "kbd": true, "label": true, "legend": true, "li": true, "link": true,
+    "main": true, "map": true, "mark": true, "math": true, "menu": true,
+    "meta": true, "meter": true, "nav": true, "noscript": true, "object": true,
+    "ol": true, "optgroup": true, "option": true, "output": true, "p": true,
+    "param": true, "picture": true, "pre": true, "progress": true,
+    "q": true, "rp": true, "rt": true, "ruby": true,
+    "s": true, "samp": true, "script": true, "search": true, "section": true,
+    "select": true, "slot": true, "small": true, "source": true, "span": true,
+    "strong": true, "style": true, "sub": true, "summary": true, "sup": true,
+    "svg": true, "table": true, "tbody": true, "td": true, "template": true,
+    "textarea": true, "tfoot": true, "th": true, "thead": true, "time": true,
+    "title": true, "tr": true, "track": true,
+    "u": true, "ul": true, "var": true, "video": true, "wbr": true
+}
+
+// Find all angle bracket tokens in scope and report only those in prose
+found := text.re_find("<[A-Za-z][\\w\\s._\\-|]*>", scope, -1)
 if !is_undefined(found) {
-    search_from := 0
     for group in found {
         m := group[0]
-        tag := text.to_lower(text.trim(m.text, "<>"))
-        tag_name := text.split(tag, " ")[0]
 
-        // Skip known HTML5 tags
-        html_tags := {
-            "a": true, "abbr": true, "address": true, "area": true, "article": true,
-            "aside": true, "audio": true, "b": true, "base": true, "bdi": true,
-            "bdo": true, "blockquote": true, "body": true, "br": true, "button": true,
-            "canvas": true, "caption": true, "cite": true, "code": true, "col": true,
-            "colgroup": true, "data": true, "datalist": true, "dd": true, "del": true,
-            "details": true, "dfn": true, "dialog": true, "div": true, "dl": true,
-            "dt": true, "em": true, "embed": true, "fencedframe": true, "fieldset": true,
-            "figcaption": true, "figure": true, "footer": true, "form": true,
-            "h1": true, "h2": true, "h3": true, "h4": true, "h5": true, "h6": true,
-            "head": true, "header": true, "hgroup": true, "hr": true, "html": true,
-            "i": true, "iframe": true, "img": true, "input": true, "ins": true,
-            "kbd": true, "label": true, "legend": true, "li": true, "link": true,
-            "main": true, "map": true, "mark": true, "math": true, "menu": true,
-            "meta": true, "meter": true, "nav": true, "noscript": true, "object": true,
-            "ol": true, "optgroup": true, "option": true, "output": true, "p": true,
-            "param": true, "picture": true, "pre": true, "progress": true,
-            "q": true, "rp": true, "rt": true, "ruby": true,
-            "s": true, "samp": true, "script": true, "search": true, "section": true,
-            "select": true, "slot": true, "small": true, "source": true, "span": true,
-            "strong": true, "style": true, "sub": true, "summary": true, "sup": true,
-            "svg": true, "table": true, "tbody": true, "td": true, "template": true,
-            "textarea": true, "tfoot": true, "th": true, "thead": true, "time": true,
-            "title": true, "tr": true, "track": true,
-            "u": true, "ul": true, "var": true, "video": true, "wbr": true
+        // Skip if match falls within an ignored range
+        in_ignored := false
+        for r in ignored {
+            if m.begin >= r.s && m.end <= r.e {
+                in_ignored = true
+                break
+            }
         }
 
-        if !html_tags[tag_name] {
-            // Find this match in the original scope, starting from search_from
-            // to correctly handle duplicate placeholder text
-            pos := text.index(scope[search_from:], m.text)
-            if pos >= 0 {
-                abs_pos := search_from + pos
-                matches = append(matches, {begin: abs_pos, end: abs_pos + len(m.text)})
-                search_from = abs_pos + len(m.text)
+        if !in_ignored {
+            tag := text.to_lower(text.trim(m.text, "<>"))
+            tag_name := text.split(tag, " ")[0]
+            if !html_tags[tag_name] {
+                matches = append(matches, {begin: m.begin, end: m.end})
             }
         }
     }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does**:
Adds a new Vale rule `Gardener.AngleBrackets` that flags placeholder syntax  when it appears unescaped in prose.

**Why this PR is needed:**
Unescaped angle brackets (e.g. &lt;pod-name&gt;) used in Markdown prose are parsed by VitePress as HTML tags. This breaks the build ([example PR fixing the problem in one of the source repos](https://github.com/gardener/etcd-druid/pull/1365)).

**What was added**:

- `AngleBrackets.yml` — Vale rule definition
- `AngleBrackets.tengo` — Tengo script that implements the detection logic

Usually, Vale skips over code blocks and HTML elements — including anything that looks like an HTML tag, such as &lt;pod-name&gt;. In order to lint expressions in angle brackets, the Vale rule has to use `scope: raw`. This leads to Vale linting the raw Markdown file. However, this poses one problem - with `scope: raw`, Vale lints inside code blocks and inline code. To prevent that, a Tengo script was added. The script removes code blocks and inline code before searching for matches.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @klocke-io 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved documentation validation for angle-bracket content by adding a dedicated check that flags unescaped placeholders and unknown HTML tags in raw text.
  * Error messages now include clearer guidance on how to format valid placeholders or configure allowance for known tags.
  * Updated the ignore behavior so angle-bracket token patterns are no longer broadly excluded, allowing the new rule to run as intended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->