### PR TITLE
feat(ci): add scheduled content aggregation (PR 1/2)

### DIFF
--- a/.github/workflows/aggregate-content.yml
+++ b/.github/workflows/aggregate-content.yml
@@ -6,8 +6,8 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  id-token: write
+  contents: read
 
 concurrency:
   group: aggregate-content
@@ -16,11 +16,26 @@ concurrency:
 jobs:
   aggregate:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: read
     steps:
+      - name: Federated GitHub token
+        uses: gardener/cc-utils/.github/actions/github-auth@v1
+        id: app-token
+        with:
+          token-server: ${{ vars.FEDERATED_GITHUB_ACCESS_TOKEN_SERVER }}
+          repositories: ${{ github.event.repository.name }}
+          permissions: |
+            contents: write
+            pull-requests: write
+
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
+          persist-credentials: true
 
       - uses: actions/setup-node@v4
         with:
@@ -29,6 +44,9 @@ jobs:
       - name: Install deps
         run: npm ci
 
+      # Docforge primarily reads via raw.githubusercontent.com which does not
+      # consume GitHub API rate limits. The default GITHUB_TOKEN authenticates
+      # the smaller number of metadata API calls.
       - name: Aggregate (docforge)
         env:
           DOCFORGE_CONFIG: .docforge/config.yaml
@@ -46,8 +64,8 @@ jobs:
       - name: Push on success
         if: steps.build.outcome == 'success'
         run: |
-          git config user.name  "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name  "federated-github-access[bot]"
+          git config user.email "248678271+federated-github-access[bot]@users.noreply.github.com"
           git add hugo/content/
           if git diff --cached --quiet; then
             echo "No content changes"
@@ -60,15 +78,13 @@ jobs:
         if: steps.build.outcome == 'failure'
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ steps.app-token.outputs.token }}
           branch: bot/content-aggregation-failure
-          title: "🚨 Content aggregation build failed"
+          title: "🚨 Content aggregation build failed (${{ github.run_started_at }})"
           body: |
             Daily content aggregation produced a tree that fails `make build`.
 
             **Action required:** review the diff, fix the broken upstream source(s),
             then close this PR (next nightly run will pick up the fix).
-
-            **Note:** If no CI checks ran on this PR, close and reopen it once —
-            PRs created by `GITHUB_TOKEN` do not trigger downstream workflows by default.
           commit-message: "chore(content): aggregation with build failure"
           add-paths: hugo/content/

--- a/.github/workflows/aggregate-content.yml
+++ b/.github/workflows/aggregate-content.yml
@@ -1,0 +1,74 @@
+name: Aggregate Documentation Content
+
+on:
+  schedule:
+    - cron: '0 4 * * 1-5'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: aggregate-content
+  cancel-in-progress: false
+
+jobs:
+  aggregate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Aggregate (docforge)
+        env:
+          DOCFORGE_CONFIG: .docforge/config.yaml
+          GITHUB_OAUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: make docforge-ci
+
+      - name: Post-process
+        run: make post-process
+
+      - name: Verify build
+        id: build
+        run: make build
+        continue-on-error: true
+
+      - name: Push on success
+        if: steps.build.outcome == 'success'
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add hugo/content/
+          if git diff --cached --quiet; then
+            echo "No content changes"
+            exit 0
+          fi
+          git commit -m "chore(content): aggregate docs $(date -u +%Y-%m-%d)"
+          git push origin HEAD:${{ github.ref_name }}
+
+      - name: Open PR on failure
+        if: steps.build.outcome == 'failure'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: bot/content-aggregation-failure
+          title: "🚨 Content aggregation build failed"
+          body: |
+            Daily content aggregation produced a tree that fails `make build`.
+
+            **Action required:** review the diff, fix the broken upstream source(s),
+            then close this PR (next nightly run will pick up the fix).
+
+            **Note:** If no CI checks ran on this PR, close and reopen it once —
+            PRs created by `GITHUB_TOKEN` do not trigger downstream workflows by default.
+          commit-message: "chore(content): aggregation with build failure"
+          add-paths: hugo/content/

--- a/.gitignore
+++ b/.gitignore
@@ -2,20 +2,15 @@
 .idea
 .worktrees
 worktrees
-hugo/public
 node_modules
 hugo/resources/_gen
 hugo/.forestry
 .DS_Store
 *.yaml
 
-hugo/**
-
-!.github/**/*.yaml
 !.docforge/**/*.yaml
 !pnpm-lock.yaml
 !pnpm-workspace.yaml
-content
 .vitepress/theme/utils/debug/**
 
 ### Start: https://github.com/github/gitignore/blob/main/Node.gitignore ###

--- a/Makefile
+++ b/Makefile
@@ -158,12 +158,17 @@ post-processing-part-index:
 post-processing-part-3:
 	node post-processing/part-3.js --update-report-link --process-api-html
 
+.PHONY: post-processing-part-managed
+post-processing-part-managed:
+	node post-processing/part-managed.js ./hugo/content
+
 .PHONY: post-process
 post-process: ## Run post-processing scripts
 	@$(MAKE) post-processing-part-1
 	@$(MAKE) post-processing-part-2
 	@$(MAKE) post-processing-part-index
 	@$(MAKE) post-processing-part-3
+	@$(MAKE) post-processing-part-managed
 
 .PHONY: build
 build: ## Build the documentation site

--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,18 @@ docforge-ci: docforge-download ## Run docforge in CI mode (non-interactive)
 	./bin/docforge
 
 .PHONY: ci-build
-ci-build: docforge-ci ci-install post-process build ## Run all steps for building in CI
+ci-build: ## Build for CI/Netlify: skip aggregation if hugo/content/ is already committed, otherwise run the full pipeline
+	@if [ -d hugo/content ]; then \
+		echo "hugo/content/ found — using committed tree, skipping docforge + post-process"; \
+		$(MAKE) ci-install; \
+		$(MAKE) build; \
+	else \
+		echo "hugo/content/ missing — running full aggregation pipeline"; \
+		$(MAKE) docforge-ci; \
+		$(MAKE) ci-install; \
+		$(MAKE) post-process; \
+		$(MAKE) build; \
+	fi
 
 .PHONY: vale-install
 vale-install: ## Install Vale binary if not already present

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-    command = "npx vitepress build"
+    command = "make ci-build"
     publish = ".vitepress/dist"
 
 [[headers]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,7 @@
+[build]
+    command = "npx vitepress build"
+    publish = ".vitepress/dist"
+
 [[headers]]
     for = "/*"
     [headers.values]

--- a/post-processing/part-managed.js
+++ b/post-processing/part-managed.js
@@ -1,0 +1,101 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import matter from 'gray-matter';
+
+const ROOT = process.argv[2] || './hugo/content';
+const TARGET_REPO = 'https://github.com/gardener/documentation';
+
+const LOCAL_REPO_PATTERN = /^https?:\/\/github\.com\/gardener\/documentation\/?$/;
+const LOCAL_SUBDIR_PATTERN = /^website(\/|$)/;
+const LOCAL_PATH_ALLOWLIST = [/^_index\.md$/, /^index\.md$/];
+
+function seedClassification(fm, relativePath) {
+  if (LOCAL_PATH_ALLOWLIST.some(re => re.test(relativePath))) return 'local';
+  if (typeof fm.github_repo === 'string'
+      && typeof fm.github_subdir === 'string'
+      && LOCAL_REPO_PATTERN.test(fm.github_repo)
+      && LOCAL_SUBDIR_PATTERN.test(fm.github_subdir)) {
+    return 'local';
+  }
+  return 'managed';
+}
+
+function rewriteLocalEditLink(fm, relativePath) {
+  const dir = path.posix.dirname(relativePath);
+  const base = path.posix.basename(relativePath);
+  fm.github_repo = TARGET_REPO;
+  fm.github_subdir = dir === '.' ? 'hugo/content' : `hugo/content/${dir}`;
+  fm.path_base_for_github_subdir = { from: `content/${relativePath}`, to: base };
+}
+
+async function walk(dir, root, counters) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) await walk(full, root, counters);
+    else if (entry.isFile() && entry.name.endsWith('.md')) await processFile(full, root, counters);
+  }
+}
+
+async function processFile(file, root, counters) {
+  const raw = await fs.readFile(file, 'utf8');
+  // gray-matter shares `data` refs for byte-identical inputs; part-index.js
+  // creates _index.md/index.md byte-twins. Disable cache so mutations stay
+  // file-local and idempotency holds.
+  const parsed = matter(raw, { cache: false });
+  const relativePath = path.relative(root, file).split(path.sep).join('/');
+  const fm = parsed.data;
+
+  const hasLocal = fm.local === true;
+  const hasManaged = fm.managed === true;
+  if (hasLocal && hasManaged) {
+    throw new Error(
+      `Data corruption: file has BOTH 'local: true' and 'managed: true' — ${file}. ` +
+      `Resolve manually before re-running part-managed.js.`
+    );
+  }
+
+  let classification;
+  if (hasLocal) classification = 'local';
+  else if (hasManaged) classification = 'managed';
+  else classification = seedClassification(fm, relativePath);
+
+  let mutated = false;
+  if (classification === 'local') {
+    counters.local += 1;
+    if (!hasLocal) { fm.local = true; mutated = true; }
+    if (hasManaged) { delete fm.managed; mutated = true; }
+    const dir = path.posix.dirname(relativePath);
+    const base = path.posix.basename(relativePath);
+    const desiredSubdir = dir === '.' ? 'hugo/content' : `hugo/content/${dir}`;
+    const desiredFrom = `content/${relativePath}`;
+    const pb = fm.path_base_for_github_subdir;
+    const pbOk = pb && typeof pb === 'object' && pb.from === desiredFrom && pb.to === base;
+    if (fm.github_repo !== TARGET_REPO || fm.github_subdir !== desiredSubdir || !pbOk) {
+      rewriteLocalEditLink(fm, relativePath);
+      mutated = true;
+    }
+  } else {
+    counters.managed += 1;
+    if (!hasManaged) { fm.managed = true; mutated = true; }
+    if (hasLocal) { delete fm.local; mutated = true; }
+  }
+
+  if (mutated) {
+    const rebuilt = matter.stringify(parsed.content, fm);
+    await fs.writeFile(file, rebuilt, 'utf8');
+    counters.mutated += 1;
+  }
+}
+
+(async () => {
+  try {
+    const counters = { local: 0, managed: 0, mutated: 0 };
+    await walk(ROOT, ROOT, counters);
+    console.log(`Managed marker pass complete. local=${counters.local} managed=${counters.managed} mutated=${counters.mutated}`);
+  } catch (err) {
+    console.error('Error:', err.message);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/kind enhancement

**What this PR does / why we need it**:

First half of a two-step migration: move Docforge aggregation out of every Netlify build and into a scheduled job that commits the result to `master`. PR 2 will follow and remove the legacy on-build path.

What's in this one:

- **Scheduled workflow** (Mon–Fri 04:00 UTC + `workflow_dispatch`). Auth via OIDC federation (`gardener/cc-utils/.github/actions/github-auth@v1`) — no token secrets to manage, the org-policy block on `GITHUB_TOKEN` writes is bypassed cleanly. On success it pushes the aggregated `hugo/content/` to the branch, on failure it opens a `bot/content-aggregation-failure` PR with timestamp.
- **`post-processing/part-managed.js`** — new post-process phase. Stamps every file with either `local:` or `managed:`, and rewrites `github_repo` / `github_subdir` on local files so the "Edit this page" link survives PR 2's `website/` removal. Idempotent. Tested locally: 362 local, 651 managed, re-run gives `mutated=0`, `make build` green.
- **`make ci-build` is now conditional.** If `hugo/content/` is already committed → install + build. If missing → full aggregation pipeline. Same target works for the PR-branch state today (no committed tree yet, Netlify falls through to the full path) and the post-merge steady state (committed tree, Netlify skips aggregation). Doubles as a permanent safety net: if the scheduled workflow ever stops producing fresh trees, Netlify keeps building.
- **`netlify.toml`** points at `make ci-build` so Netlify and CI use the same entrypoint.
- **`.gitignore`**: un-ignores `hugo/content/`, drops dead `hugo/public`.


**Which issue(s) this PR fixes**:
Fixes #997 

**Special notes for your reviewer**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated documentation content aggregation workflow for scheduled and manual runs, with automatic publishing back to the repo or opening a fix PR on failure.
  * Updated build settings to use the new content aggregation CI flow.

* **Bug Fixes**
  * Improved managed/local marker processing for documentation content to keep Hugo-generated pages consistent.
  * Added validation to prevent conflicting documentation markers from being written.

* **Chores**
  * Refined ignore rules for generated content and documentation YAML to support the aggregation pipeline.
  * Updated Netlify to run the CI build command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->