### PR TITLE
Update Community Roles

### DIFF
--- a/website/contribute/contribution-process/roles.md
+++ b/website/contribute/contribution-process/roles.md
@@ -30,8 +30,8 @@ Technically, members are defined by their membership in the [Gardener GitHub org
 
 **How to become a member**
 - Fulfill listed requirements
-- Obtain sponsorship from at least two approvers
-- Open a membership request issue in [gardener/org](https://github.com/gardener/org/issues/new?template=membership.yaml); if accepted, an approver or org admin creates a PR to update [`org.yaml`](https://github.com/gardener/org/blob/main/config/org.yaml).
+- Obtain sponsorship from at least two approvers of any Gardener repository.
+- Open a membership request issue in [gardener/org](https://github.com/gardener/org/issues/new?template=membership_request.yaml); if accepted, an approver or org admin creates a PR to update [`org.yaml`](https://github.com/gardener/org/blob/main/config/org.yaml).
 
 ## Reviewer
 
@@ -40,6 +40,7 @@ They are granted the privilege to `/lgtm` pull requests.
 Contributors with this role are technically defined in the [`OWNERS_ALIASES`](https://docs.prow.k8s.io/docs/components/plugins/approve/approvers/#overview) file, placed at the root level of the repository.
 
 **Requirements**
+- Member of the Gardener org
 - Solid understanding of the codebase and software engineering principles
 - Professional expertise in at least one Gardener topic area: `core`, `infrastructure`, `networking`, `observability`, `scalability`, `security`, etc. 
   The specific areas may vary depending on the subproject.
@@ -52,8 +53,8 @@ Contributors with this role are technically defined in the [`OWNERS_ALIASES`](ht
 
 **How to become a reviewer**
 - Demonstrate the requirements through previous contributions (code changes, PR review participation, issue discussions) in the relevant topic area
-- Obtain sponsorship from at least two approvers
-- Open a [membership request](https://github.com/gardener/org/issues/new?template=membership.yaml); if accepted, an approver creates a PR to update [`OWNERS_ALIASES`](https://docs.prow.k8s.io/docs/components/plugins/approve/approvers/#overview) for the requested repository.
+- Obtain sponsorship from at least two approvers of the target repository.
+- Open a [membership request](https://github.com/gardener/org/issues/new?template=membership_role.yaml); if accepted, an approver creates a PR to update [`OWNERS_ALIASES`](https://docs.prow.k8s.io/docs/components/plugins/approve/approvers/#overview) for the requested repository.
 
 ## Approver
 
@@ -64,10 +65,12 @@ Contributors with this role are technically defined in the [`OWNERS_ALIASES`](ht
 Approvers share the requirements and responsibilities of [reviewers](#reviewer), with additional expectations:
 
 **Requirements**
+- Reviewer role for >= 3 months
 - Sound technical judgment
 - Deep understanding of the Gardener codebase, features, and extensions
 - Strong operational experience with Gardener
 - Active community engagement in the form of contributions to the [Gardener Community Review meeting](../../../community/_index.md#gardener-review-meetings), [Slack](https://join.slack.com/t/gardener-cloud/shared_invite/zt-33c9daems-3oOorhnqOSnldZPWqGmIBw) discussions or similar
+
 **Responsibilities**
 - General Responsiveness for subproject matters
 - Triage reviews and issues (status check, categorizing, prioritizing)
@@ -76,8 +79,7 @@ Approvers share the requirements and responsibilities of [reviewers](#reviewer),
 - Regular contributions across multiple topic areas, including larger changes and refactorings
 
 **How to become an approver**
-- Serve as a reviewer for at least 3 months
-- Obtain sponsorship from a quorum of approvers; nomination is initiated by one or more existing approvers through a new PR, which must receive positive reviews from the quorum.
+- Obtain sponsorship from a quorum of approvers of the target repository; nomination is initiated by one or more existing approvers through a new PR, which must receive positive reviews from the quorum.
 
 ## Adjustment of Membership Status
 

--- a/website/contribute/contribution-process/roles.md
+++ b/website/contribute/contribution-process/roles.md
@@ -31,7 +31,7 @@ Technically, members are defined by their membership in the [Gardener GitHub org
 **How to become a member**
 - Fulfill listed requirements
 - Obtain sponsorship from at least two approvers
-- Open a membership request issue in [gardener/org](https://github.com/gardener/org/issues/new?template=membership.yaml); if accepted, an org owner assigns the member to the corresponding group.
+- Open a membership request issue in [gardener/org](https://github.com/gardener/org/issues/new?template=membership.yaml); if accepted, an approver or org admin creates a PR to update [`org.yaml`](https://github.com/gardener/org/blob/main/config/org.yaml).
 
 ## Reviewer
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Updates the community role documentation after enabling declarative membership maintenance (Peribolos).

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/org/issues/2

**Special notes for your reviewer**:
/cc @oliver-goetz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated community role qualification guidance and eligibility criteria.
  * Clarified the request process for Members and Reviewers with the latest issue templates.
  * Added a clearer tenure requirement for Approvers and refreshed the nomination/sponsorship steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->