### PR TITLE
Update Podrick button and formatting guide

### DIFF
--- a/website/contribute/documentation/formatting-guide.md
+++ b/website/contribute/documentation/formatting-guide.md
@@ -9,7 +9,7 @@ These are guidelines, not rules. Use your best judgment, and feel free to propos
 
 * [Formatting of Inline Elements](#formatting-of-inline-elements)
 * [Headings](#headings)
-* [Calls to action](#calls-to-action)
+* [Calls to Action](#calls-to-action)
 * [Code Snippet Formatting](#code-snippet-formatting)
 * [Related Links](#related-links)
 
@@ -120,9 +120,12 @@ Another thing to keep in mind is that markdown links do not work in certain [sho
 * Use H3 for any sub-section in the main sections. (`### H3 Title`)
 * Avoid using H4-H6. Try moving the additional information to a new topic instead.
 
-## Calls to action
+## Calls to Action
 
 Use sentence case for call-to-action buttons and links (such as "Learn more", "Edit this page", "Join the group"). Only the first word and proper nouns are capitalized.
+
+> [!NOTE]
+> If a call to action appears inside a heading, use title case instead of sentence case. See [Creating Titles and Headings](./style-guide/_index.md#creating-titles-and-headings).
 
 |  Do  | Don't |
 |:---|:---|

--- a/website/contribute/documentation/formatting-guide.md
+++ b/website/contribute/documentation/formatting-guide.md
@@ -8,6 +8,8 @@ This page gives writing formatting guidelines for the Gardener documentation. Fo
 These are guidelines, not rules. Use your best judgment, and feel free to propose changes to this document in a pull request.
 
 * [Formatting of Inline Elements](#formatting-of-inline-elements)
+* [Headings](#headings)
+* [Calls to action](#calls-to-action)
 * [Code Snippet Formatting](#code-snippet-formatting)
 * [Related Links](#related-links)
 
@@ -22,7 +24,6 @@ These are guidelines, not rules. Use your best judgment, and feel free to propos
 | [Inline Code and Inline Commands](#inline-code-and-inline-commands)| `code` | <code>For declarative management, use \`kubectl apply\`.</code> |
 | [Object Field Names and Field Values](#object-field-names-and-field-values)|`code` | <code>Set the value of \`image\` to \`nginx:1.8\`.</code> |
 | [Links and References](#links-and-references) | [link]() | `Visit the [Gardener website](https://gardener.cloud/)` |
-| [Headers](#headers) | various | `# API Server` |
 
 ### API Objects and Technical Components
 
@@ -102,6 +103,8 @@ Use backticks (\`) for field names, and field values.
 
 ### Links and References
 
+Use descriptive link text that tells the reader where the link goes. Use relative links for content within the same repository.
+
 |  Do  | Don't |
 |:---|:---|
 | Use a descriptor of the link's destination: "For more information, visit [Gardener's website](#links-and-references)." | Use a generic placeholder: "For more information, go [here](#links-and-references)." |
@@ -110,12 +113,21 @@ Use backticks (\`) for field names, and field values.
 
 Another thing to keep in mind is that markdown links do not work in certain [shortcodes](./shortcodes.md) (e.g., mermaid). To circumvent this problem, you can use HTML links.
 
-### Headers
+## Headings
 
 * Use H1 for the title of the topic. (`# H1 Title`)
 * Use H2 for each main section. (`## H2 Title`)
 * Use H3 for any sub-section in the main sections. (`### H3 Title`)
 * Avoid using H4-H6. Try moving the additional information to a new topic instead.
+
+## Calls to action
+
+Use sentence case for call-to-action buttons and links (such as "Learn more", "Edit this page", "Join the group"). Only the first word and proper nouns are capitalized.
+
+|  Do  | Don't |
+|:---|:---|
+| Learn more | Learn More |
+| Edit this page | Edit This Page |
 
 ## Code Snippet Formatting
 

--- a/website/contribute/documentation/formatting-guide.md
+++ b/website/contribute/documentation/formatting-guide.md
@@ -59,7 +59,7 @@ Use **bold** to emphasize something or to introduce a new term.
 
 ### Technical Names
 
-Use backticks (\`) for filenames, technical componentes, directories, and paths.
+Use backticks (\`) for filenames, technical components, directories, and paths.
 
 |  Do  | Don't |
 |:---|:---|
@@ -108,8 +108,8 @@ Use descriptive link text that tells the reader where the link goes. Use relativ
 |  Do  | Don't |
 |:---|:---|
 | Use a descriptor of the link's destination: "For more information, visit [Gardener's website](#links-and-references)." | Use a generic placeholder: "For more information, go [here](#links-and-references)." |
-| Use relative links when linking to content in the same repository: `[Style Guide](../style-guide/_index.md)`| Use absolute links when linking to content in the same repository: `[Style Guide](https://github.com/gardener/documentation/blob/master/website/documentation/contribute/documentation/style-guide/_index.md)` |
-| Use GitHub links for absolute links to documentation content: `[Gardener API Server](https://github.com/gardener/gardener/blob/master/docs/usage/shoot_access.md)` | Use website links for documentation content: `[Gardener API Server](https://gardener.cloud/docs/gardener/usage/shoot_access/)` |
+| When linking to **content in the same repository**, use **relative links**: `[Style Guide](../style-guide/_index.md)`| Use absolute links when linking to content in the same repository: `[Style Guide](https://github.com/gardener/documentation/blob/master/website/documentation/contribute/documentation/style-guide/_index.md)` |
+| When linking to **content pulled from a different repository**, use **GitHub links**: `[Gardener API Server](https://github.com/gardener/gardener/blob/master/docs/usage/shoot_access.md)` | Use website links for documentation content: `[Gardener API Server](https://gardener.cloud/docs/gardener/usage/shoot_access/)` |
 
 Another thing to keep in mind is that markdown links do not work in certain [shortcodes](./shortcodes.md) (e.g., mermaid). To circumvent this problem, you can use HTML links.
 

--- a/website/contribute/documentation/style-guide/_index.md
+++ b/website/contribute/documentation/style-guide/_index.md
@@ -18,7 +18,7 @@ These are guidelines, not rules. Use your best judgment, and feel free to propos
 - [Language and Grammar](#language-and-grammar)
   - [Language](#language)
   - [Writing Style](#writing-style)
-  - [Creating Titles and Headers](#creating-titles-and-headers)
+  - [Creating Titles and Headings](#creating-titles-and-headings)
 - [Related Links](#related-links)
 
 ## Structure
@@ -92,9 +92,9 @@ There are a number of [predefined](https://gohugo.io/content-management/front-ma
 
 - `aliases` is an array of strings that contain the old paths to the topic. Useful in case you need to rename or change the location of a topic, but want to keep any existing bookmarks.
 
-While this section will be automatically generated if your topic has a title header, adding more detailed information helps other users, developers, and technical writers better sort, classify and understand the topic.
+While this section will be automatically generated if your topic has a title heading, adding more detailed information helps other users, developers, and technical writers better sort, classify and understand the topic.
 
-By using a metadata section you can also skip adding a title header or overwrite it in the navigation section.
+By using a metadata section you can also skip adding a title heading or overwrite it in the navigation section.
 
 #### Blogs
 
@@ -143,10 +143,10 @@ If you want to add an image to your topic, it is recommended to follow the guide
 - Be friendly and refer to the person reading your content as "you", instead of standard terms such as "user"
 - Use an active voice - make it clear who is performing the action
 
-### Creating Titles and Headers
+### Creating Titles and Headings
 
-- Use [title case](https://titlecaseconverter.com/words-to-capitalize/) when creating titles or headers
-- Avoid adding additional formatting to the title or header
+- Use [title case](https://titlecaseconverter.com/words-to-capitalize/) when creating titles or headings
+- Avoid adding additional formatting to the title or headings
 - Concept and reference topic titles should be simple and succinct
 - Task and tutorial topic titles begin with a verb
 

--- a/website/index.md
+++ b/website/index.md
@@ -9,7 +9,7 @@ hero:
   text: A Managed Kubernetes Service Done Right
   tagline: Deliver fully-managed clusters at scale everywhere with your own Gardener installation
   actions:
-    - theme: brand
+    - theme: alt
       text: Learn More with Podrick
       link: /docs/getting-started/podrick-and-the-infinite-garden.md
   image:

--- a/website/index.md
+++ b/website/index.md
@@ -10,7 +10,7 @@ hero:
   tagline: Deliver fully-managed clusters at scale everywhere with your own Gardener installation
   actions:
     - theme: alt
-      text: Learn More with Podrick
+      text: Learn more with Podrick
       link: /docs/getting-started/podrick-and-the-infinite-garden.md
   image:
     src: /gardener-logo.svg


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind cleanup

**What this PR does / why we need it**:

After the demo button was removed in commit 8d29527, the theme of the "Learn more with Podrick" button changed, causing its image to disappear:

<img width="1431" height="719" alt="image" src="https://github.com/user-attachments/assets/c5a89bb0-1060-4f86-8eb6-120aa7ca579e" />

This PR changes the theme for the Podrick button from `brand` to `alt` in order to make the image visible again.

Additionally, the PR:
- Updates the button text from title case ("Learn More with Podrick") to sentence case ("Learn more with Podrick") to match the capitalization of other calls to action, such as the "Edit this page" and "Report an issue" links.
- Updates the [Formatting Guide](https://gardener.cloud/contribute/documentation/formatting-guide/) to include guidelines for formatting call-to-action links and buttons.
- Cleans up some of the wording and terminology in the [Formatting Guide](https://gardener.cloud/contribute/documentation/formatting-guide/) uns [Style Guide](https://gardener.cloud/contribute/documentation/style-guide/)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
