### PR TITLE
fix(ci): honor upstream branch and drop broken manual trigger

### DIFF
--- a/.github/workflows/enforce-managed-files.yml
+++ b/.github/workflows/enforce-managed-files.yml
@@ -5,7 +5,6 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - 'hugo/content/**/*.md'
-  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/hack/check-managed.mjs
+++ b/hack/check-managed.mjs
@@ -10,8 +10,9 @@ for (const file of files) {
     const raw = await fs.readFile(file, 'utf8')
     const parsed = matter(raw)
     if (parsed.data.managed === true) {
+      const branch = parsed.data.params?.github_branch || 'master'
       const upstream = parsed.data.github_repo && parsed.data.github_subdir
-        ? `${parsed.data.github_repo}/blob/master/${parsed.data.github_subdir}`
+        ? `${parsed.data.github_repo}/blob/${branch}/${parsed.data.github_subdir}`
         : '(unknown source)'
       violations.push({ file, upstream })
     }


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

Fixes two independent issues in the managed-files enforcement:

- `hack/check-managed.mjs`: the edit-URL branch was hardcoded to `master`, ignoring `params.github_branch` in the frontmatter. Managed files aggregated from upstream repos on other branches (e.g. `main`) got a broken edit link. Now derives the branch from `params.github_branch`, falling back to `master`.
- `.github/workflows/enforce-managed-files.yml`: `workflow_dispatch` allowed manual runs, but `github.base_ref` is empty outside `pull_request` events. That turned the diff into `git diff "origin/...HEAD"`, failing with `fatal: bad revision`. The workflow only makes sense in PR context, so the trigger is removed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Both issues were reported in review of #1025 and reproduced locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated managed-file checks to run automatically for relevant content changes.
  * Removed the option to manually trigger these checks from the GitHub interface.
  * Upstream edit links now use the configured repository branch, defaulting to `master`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->