### PR TITLE
feat: add refresh command for local testing of docforge mainfests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,14 @@ ci-build:
 	$(MAKE) ci-install; \
 	$(MAKE) build; \
 
+.PHONY: external-hugo-refresh
+external-hugo-refresh:
+	@echo "Refreshing md files from external repositories, defined in .docforge/ dir."; \
+	@echo "USE THIS ONLY FOR TESTING OF MANIFEST CHANGES"; \
+    $(MAKE) docforge-ci; \
+    $(MAKE) post-process; \
+
+
 .PHONY: vale-install
 vale-install: ## Install Vale binary if not already present
 	@if [ -x bin/vale ]; then \

--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ Gardener documentation pulls content from multiple repositories. Key remote sour
 
 To modify these, submit changes to their respective repositories.
 
+Changes in the docforge manifests (`.docforge/*.yaml`) can be locally tested by running `make external-hugo-refresh` to pull the latest content from upstream repositories.
+This is only meant for testing!
+
+
 ## 🔧 Available Commands
 
 ### Documentation Development


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind TODO

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command to refresh Markdown content from configured external sources for local testing.
* **Documentation**
  * Documented how to test changes to content manifest files locally.
  * Clarified that the refresh workflow is intended for testing purposes only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->