### PR TITLE
docs: add Documentation Maintainer community role

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation_reviewer_role.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation_reviewer_role.yaml
@@ -1,0 +1,66 @@
+# Modifications Copyright SAP SE or an SAP affiliate company and Gardener contributors.
+name: Documentation Reviewer Role Request
+description: Request the documentation reviewer role
+labels: ["kind/task"]
+title: "Documentation reviewer role for <your-GH-handle>"
+body:
+- id: motivation
+  type: textarea
+  attributes:
+    label: "Motivation"
+    description: Describe the motivation of this request and your background shortly - we'd like to know you :-)
+- id: github
+  type: input
+  attributes:
+    label: GitHub Username
+    placeholder: e.g. @example_user
+  validations:
+    required: true
+- id: requirements
+  type: checkboxes
+  attributes:
+    label: Requirements
+    description: See [documentation roles](https://gardener.cloud/contribute/contribution-process/documentation-roles/#documentation-reviewer).
+    options:
+    - label: I've read the [Gardener contributor guide](https://gardener.cloud/contribute/contribution-process/contributor-guide/).
+      required: true
+    - label: I'm a member of the Gardener org.
+      required: true
+    - label: I have a solid understanding of the Gardener documentation structure.
+      required: true
+    - label: I'm familiar with the documentation tooling, i.e., [Docforge](https://github.com/gardener/docforge) aggregation, the [VitePress](https://vitepress.dev/) site generator, Markdown, and the local build, post-processing, and preview workflow.
+      required: true
+    - label: I have enabled GitHub notifications for PR invites and documentation issues.
+      required: true
+    - label: I verified my sponsors are approvers of the [documentation repository](https://github.com/gardener/documentation).
+      required: true
+    - label: I have spoken to my sponsors ahead of this application, and they have agreed to sponsor my application.
+      required: true
+    - label: I prepared and attached a record of contributions in this issue.
+      required: true
+- id: sponsor_1
+  type: input
+  attributes:
+    label: "Sponsor 1"
+    description: GitHub handle of your sponsor (approver of the documentation repository)
+    placeholder: e.g. @...
+  validations:
+    required: true
+- id: sponsor_2
+  type: input
+  attributes:
+    label: "Sponsor 2"
+    description: GitHub handle of your sponsor (approver of the documentation repository)
+    placeholder: e.g. @...
+  validations:
+    required: true
+- id: contributions
+  type: textarea
+  attributes:
+    label: List of contributions to the Gardener documentation
+    placeholder: |
+      - Documentation PRs authored / reviewed
+      - Documentation issues responded to
+      - Structural or editorial improvements
+  validations:
+    required: true

--- a/hugo/content/contribute/contribution-process/_index.md
+++ b/hugo/content/contribute/contribution-process/_index.md
@@ -21,4 +21,5 @@ Start here to understand how contributions work, what's required, how reviews ha
 
 - [Contributor Guide](/contribute/contribution-process/contributor-guide/): Prerequisites, submission process, and tips for getting your contributions accepted
 - [Community Roles](/contribute/contribution-process/roles/): The different roles within the Gardener community, their tasks and responsibilities
+- [Documentation Roles](/contribute/contribution-process/documentation-roles/): Documentation-specific roles, such as the documentation reviewer and approver as well as their requirements
 - [Contributing Bigger Changes](/contribute/contribution-process/contributing-bigger-changes/): Guidelines for scoping and structuring large contributions

--- a/hugo/content/contribute/contribution-process/documentation-roles.md
+++ b/hugo/content/contribute/contribution-process/documentation-roles.md
@@ -3,13 +3,13 @@ aliases:
   - /docs/contribute/code/documentation-roles/
 github_repo: 'https://github.com/gardener/documentation'
 github_subdir: hugo/content/contribute/contribution-process
-outline: 2
 params:
   github_branch: master
 path_base_for_github_subdir:
   from: content/contribute/contribution-process/documentation-roles.md
   to: documentation-roles.md
 title: "Documentation Roles"
+outline: 2
 weight: 40
 prev: false
 next: false
@@ -46,7 +46,7 @@ Reviewers are technically defined in the [`OWNERS_ALIASES`](https://github.com/g
 **How to become a documentation reviewer**
 - Demonstrate the requirements through previous contributions (documentation changes, PR review participation, issue discussions).
 - Obtain sponsorship from at least two approvers of the [documentation repository](https://github.com/gardener/documentation).
-- Open a [membership request](https://github.com/gardener/org/issues/new?template=membership_role.yaml). If accepted, an approver creates a PR to update [`OWNERS_ALIASES`](https://github.com/gardener/documentation/blob/master/OWNERS_ALIASES) of the documentation repository.
+- Open a [documentation reviewer request](https://github.com/gardener/documentation/issues/new?template=documentation_reviewer_role.yaml). If accepted, an approver creates a PR to update [`OWNERS_ALIASES`](https://github.com/gardener/documentation/blob/master/OWNERS_ALIASES) of the documentation repository.
 
 ## Documentation Approver
 
@@ -65,5 +65,4 @@ They are granted the privilege to approve pull requests by using the `/approve` 
 - Never alter the underlying meaning of content in other repositories without prior approval from an [approver](/contribute/contribution-process/roles/#approver) of that repository
 
 **How to become a documentation approver**
-- Obtain sponsorship from a quorum of approvers of the [documentation repository](https://github.com/gardener/documentation). Nomination is initiated by one or more existing documentation approvers through a new PR.
-- Cross-repository access is granted by adding the `documentation-approvers` alias to the `/docs` `OWNERS` (or `OWNERS_ALIASES`) of each referenced repository, scoping the role to the documentation paths aggregated by Docforge. An approver of the respective repository performs this change.
+- Obtain sponsorship from a quorum of approvers of the target repository; nomination is initiated by one or more existing approvers through a new PR, which must receive positive reviews from the quorum.

--- a/hugo/content/contribute/contribution-process/documentation-roles.md
+++ b/hugo/content/contribute/contribution-process/documentation-roles.md
@@ -19,16 +19,16 @@ local: true
 # Documentation Roles
 
 This document describes documentation-specific contribution roles within the Gardener community.
-The [general community roles](/contribute/contribution-process/roles/) are tailored to code repositories; documentation roles have their own requirements and responsibilities, because maintaining the aggregated documentation across the different repositories requires editorial and structural expertise.
+The [general community roles](/contribute/contribution-process/roles/) are tailored to code repositories. Documentation roles have their own requirements and responsibilities because maintaining the aggregated documentation across the different repositories requires editorial and structural expertise.
 
-> [!Note]
+> [!NOTE]
 > Documentation roles are defined in the [`OWNERS_ALIASES`](https://github.com/gardener/documentation/blob/master/OWNERS_ALIASES) file of the [documentation repository](https://github.com/gardener/documentation).
 
 ## Documentation Reviewer
 
 Documentation reviewers are responsible for assessing the quality, clarity, and structural correctness of documentation contributions.
 They are granted the privilege to `/lgtm` pull requests on the [documentation repository](https://github.com/gardener/documentation).
-Contributors with this role are technically defined in the [`OWNERS_ALIASES`](https://github.com/gardener/documentation/blob/master/OWNERS_ALIASES) file of the documentation repository.
+Reviewers are technically defined in the [`OWNERS_ALIASES`](https://github.com/gardener/documentation/blob/master/OWNERS_ALIASES) file of the documentation repository.
 
 Unlike [reviewers](/contribute/contribution-process/roles/#reviewer), documentation reviewers do not require professional expertise in a specific Gardener topic area, but should have a solid understanding of the documentation structure and editorial conventions.
 
@@ -44,16 +44,16 @@ Unlike [reviewers](/contribute/contribution-process/roles/#reviewer), documentat
 - Responsiveness, especially during documentation reviews and discussions
 
 **How to become a documentation reviewer**
-- Demonstrate the requirements through previous contributions (documentation changes, PR review participation, issue discussions)
+- Demonstrate the requirements through previous contributions (documentation changes, PR review participation, issue discussions).
 - Obtain sponsorship from at least two approvers of the [documentation repository](https://github.com/gardener/documentation).
-- Open a [membership request](https://github.com/gardener/org/issues/new?template=membership_role.yaml); if accepted, an approver creates a PR to update [`OWNERS_ALIASES`](https://github.com/gardener/documentation/blob/master/OWNERS_ALIASES) of the documentation repository.
+- Open a [membership request](https://github.com/gardener/org/issues/new?template=membership_role.yaml). If accepted, an approver creates a PR to update [`OWNERS_ALIASES`](https://github.com/gardener/documentation/blob/master/OWNERS_ALIASES) of the documentation repository.
 
 ## Documentation Approver
 
 Documentation approvers are deeply involved in the holistic maintenance, structure, and operation of the [Gardener documentation](https://gardener.cloud/).
 In addition to approver permissions on the [documentation repository](https://github.com/gardener/documentation), they hold approver permissions for the `/docs` folder of every project referenced in the [docforge manifest files](https://github.com/gardener/documentation/tree/master/.docforge), which [docforge](https://github.com/gardener/docforge) aggregates into the final documentation.
 This cross-repository permission ensures smooth documentation maintenance, comparable to setups where all documentation lives in one central repository rather than being colocated with the code.
-They are granted the privilege to `/approve` pull requests.
+They are granted the privilege to approve pull requests by using the `/approve` comment.
 
 Unlike [approvers](/contribute/contribution-process/roles/#approver), documentation approvers do not require deep technical expertise across the various components, but should still have a solid understanding of Gardener.
 Documentation approvers share the requirements and responsibilities of [documentation reviewers](#documentation-reviewer), with additional expectations:
@@ -68,5 +68,5 @@ Documentation approvers share the requirements and responsibilities of [document
 - Never alter the underlying meaning of content in other repositories without prior approval from an [approver](/contribute/contribution-process/roles/#approver) of that repository
 
 **How to become a documentation approver**
-- Obtain sponsorship from a quorum of approvers of the [documentation repository](https://github.com/gardener/documentation); nomination is initiated by one or more existing documentation approvers through a new PR.
+- Obtain sponsorship from a quorum of approvers of the [documentation repository](https://github.com/gardener/documentation). Nomination is initiated by one or more existing documentation approvers through a new PR.
 - Cross-repository access is granted by adding the `documentation-approvers` alias to the `/docs` `OWNERS` (or `OWNERS_ALIASES`) of each referenced repository, scoping the role to the documentation paths aggregated by docforge. An approver of the respective repository performs this change.

--- a/hugo/content/contribute/contribution-process/documentation-roles.md
+++ b/hugo/content/contribute/contribution-process/documentation-roles.md
@@ -29,7 +29,7 @@ To learn more about the general membership requirements and responsibilities, pl
 ## Documentation Reviewer
 
 Documentation reviewers are responsible for assessing the quality, clarity, and structural correctness of documentation contributions.
-They are granted the privilege to `/lgtm` pull requests on the [documentation repository](https://github.com/gardener/documentation).
+They are granted the privilege to use the `/lgtm` comment on pull requests in the [documentation repository](https://github.com/gardener/documentation).
 Reviewers are technically defined in the [`OWNERS_ALIASES`](https://github.com/gardener/documentation/blob/master/OWNERS_ALIASES) file of the documentation repository.
 
 **Requirements**

--- a/hugo/content/contribute/contribution-process/documentation-roles.md
+++ b/hugo/content/contribute/contribution-process/documentation-roles.md
@@ -21,8 +21,10 @@ local: true
 This document describes documentation-specific contribution roles within the Gardener community.
 The [general community roles](/contribute/contribution-process/roles/) are tailored to code repositories. Documentation roles have their own requirements and responsibilities because maintaining the aggregated documentation across the different repositories requires editorial and structural expertise.
 
-> [!NOTE]
-> Documentation roles are defined in the [`OWNERS_ALIASES`](https://github.com/gardener/documentation/blob/master/OWNERS_ALIASES) file of the [documentation repository](https://github.com/gardener/documentation).
+## Documentation Members
+
+Documentation members are the same as Gardener community members .
+To learn more about the general membership requirements and responsibilities, please refer to the [members section](/contribute/contribution-process/roles/#member).
 
 ## Documentation Reviewer
 
@@ -30,12 +32,10 @@ Documentation reviewers are responsible for assessing the quality, clarity, and 
 They are granted the privilege to `/lgtm` pull requests on the [documentation repository](https://github.com/gardener/documentation).
 Reviewers are technically defined in the [`OWNERS_ALIASES`](https://github.com/gardener/documentation/blob/master/OWNERS_ALIASES) file of the documentation repository.
 
-Unlike [reviewers](/contribute/contribution-process/roles/#reviewer), documentation reviewers do not require professional expertise in a specific Gardener topic area, but should have a solid understanding of the documentation structure and editorial conventions.
-
 **Requirements**
 - Member of the Gardener org
-- Solid understanding of the Gardener documentation structure and the docforge aggregation process
-- Familiarity with the documentation tooling, i.e., [docforge](https://github.com/gardener/docforge) aggregation, the [VitePress](https://vitepress.dev/) site generator, Markdown, and the local build, post-processing, and preview workflow
+- Solid understanding of the Gardener documentation structure.
+- Familiarity with the documentation tooling, i.e., [Docforge](https://github.com/gardener/docforge) aggregation, the [VitePress](https://vitepress.dev/) site generator, Markdown, and the local build, post-processing, and preview workflow
 - Enabled GitHub notifications for PR invites and documentation issues
 
 **Responsibilities**
@@ -51,12 +51,9 @@ Unlike [reviewers](/contribute/contribution-process/roles/#reviewer), documentat
 ## Documentation Approver
 
 Documentation approvers are deeply involved in the holistic maintenance, structure, and operation of the [Gardener documentation](https://gardener.cloud/).
-In addition to approver permissions on the [documentation repository](https://github.com/gardener/documentation), they hold approver permissions for the `/docs` folder of every project referenced in the [docforge manifest files](https://github.com/gardener/documentation/tree/master/.docforge), which [docforge](https://github.com/gardener/docforge) aggregates into the final documentation.
+In addition to approver permissions on the [documentation repository](https://github.com/gardener/documentation), they hold approver permissions for the `/docs` folder of every project referenced in the [Docforge manifest files](https://github.com/gardener/documentation/tree/master/.docforge), which [Docforge](https://github.com/gardener/docforge) aggregates into the final documentation.
 This cross-repository permission ensures smooth documentation maintenance, comparable to setups where all documentation lives in one central repository rather than being colocated with the code.
 They are granted the privilege to approve pull requests by using the `/approve` comment.
-
-Unlike [approvers](/contribute/contribution-process/roles/#approver), documentation approvers do not require deep technical expertise across the various components, but should still have a solid understanding of Gardener.
-Documentation approvers share the requirements and responsibilities of [documentation reviewers](#documentation-reviewer), with additional expectations:
 
 **Requirements**
 - Deep understanding of the Gardener documentation lifecycle
@@ -69,4 +66,4 @@ Documentation approvers share the requirements and responsibilities of [document
 
 **How to become a documentation approver**
 - Obtain sponsorship from a quorum of approvers of the [documentation repository](https://github.com/gardener/documentation). Nomination is initiated by one or more existing documentation approvers through a new PR.
-- Cross-repository access is granted by adding the `documentation-approvers` alias to the `/docs` `OWNERS` (or `OWNERS_ALIASES`) of each referenced repository, scoping the role to the documentation paths aggregated by docforge. An approver of the respective repository performs this change.
+- Cross-repository access is granted by adding the `documentation-approvers` alias to the `/docs` `OWNERS` (or `OWNERS_ALIASES`) of each referenced repository, scoping the role to the documentation paths aggregated by Docforge. An approver of the respective repository performs this change.

--- a/hugo/content/contribute/contribution-process/documentation-roles.md
+++ b/hugo/content/contribute/contribution-process/documentation-roles.md
@@ -1,0 +1,72 @@
+---
+aliases:
+  - /docs/contribute/code/documentation-roles/
+github_repo: 'https://github.com/gardener/documentation'
+github_subdir: hugo/content/contribute/contribution-process
+outline: 2
+params:
+  github_branch: master
+path_base_for_github_subdir:
+  from: content/contribute/contribution-process/documentation-roles.md
+  to: documentation-roles.md
+title: "Documentation Roles"
+weight: 40
+prev: false
+next: false
+local: true
+---
+
+# Documentation Roles
+
+This document describes documentation-specific contribution roles within the Gardener community.
+The [general community roles](/contribute/contribution-process/roles/) are tailored to code repositories; documentation roles have their own requirements and responsibilities, because maintaining the aggregated documentation across the different repositories requires editorial and structural expertise.
+
+> [!Note]
+> Documentation roles are defined in the [`OWNERS_ALIASES`](https://github.com/gardener/documentation/blob/master/OWNERS_ALIASES) file of the [documentation repository](https://github.com/gardener/documentation).
+
+## Documentation Reviewer
+
+Documentation reviewers are responsible for assessing the quality, clarity, and structural correctness of documentation contributions.
+They are granted the privilege to `/lgtm` pull requests on the [documentation repository](https://github.com/gardener/documentation).
+Contributors with this role are technically defined in the [`OWNERS_ALIASES`](https://github.com/gardener/documentation/blob/master/OWNERS_ALIASES) file of the documentation repository.
+
+Unlike [reviewers](/contribute/contribution-process/roles/#reviewer), documentation reviewers do not require professional expertise in a specific Gardener topic area, but should have a solid understanding of the documentation structure and editorial conventions.
+
+**Requirements**
+- Member of the Gardener org
+- Solid understanding of the Gardener documentation structure and the docforge aggregation process
+- Familiarity with the documentation tooling, i.e., [docforge](https://github.com/gardener/docforge) aggregation, the [VitePress](https://vitepress.dev/) site generator, Markdown, and the local build, post-processing, and preview workflow
+- Enabled GitHub notifications for PR invites and documentation issues
+
+**Responsibilities**
+- Regular contributions in the form of pull requests, reviews, and issues for the documentation
+- Tracking of open documentation pull requests and issues
+- Responsiveness, especially during documentation reviews and discussions
+
+**How to become a documentation reviewer**
+- Demonstrate the requirements through previous contributions (documentation changes, PR review participation, issue discussions)
+- Obtain sponsorship from at least two approvers of the [documentation repository](https://github.com/gardener/documentation).
+- Open a [membership request](https://github.com/gardener/org/issues/new?template=membership_role.yaml); if accepted, an approver creates a PR to update [`OWNERS_ALIASES`](https://github.com/gardener/documentation/blob/master/OWNERS_ALIASES) of the documentation repository.
+
+## Documentation Approver
+
+Documentation approvers are deeply involved in the holistic maintenance, structure, and operation of the [Gardener documentation](https://gardener.cloud/).
+In addition to approver permissions on the [documentation repository](https://github.com/gardener/documentation), they hold approver permissions for the `/docs` folder of every project referenced in the [docforge manifest files](https://github.com/gardener/documentation/tree/master/.docforge), which [docforge](https://github.com/gardener/docforge) aggregates into the final documentation.
+This cross-repository permission ensures smooth documentation maintenance, comparable to setups where all documentation lives in one central repository rather than being colocated with the code.
+They are granted the privilege to `/approve` pull requests.
+
+Unlike [approvers](/contribute/contribution-process/roles/#approver), documentation approvers do not require deep technical expertise across the various components, but should still have a solid understanding of Gardener.
+Documentation approvers share the requirements and responsibilities of [documentation reviewers](#documentation-reviewer), with additional expectations:
+
+**Requirements**
+- Deep understanding of the Gardener documentation lifecycle
+- Sustained contributions to the documentation, e.g., improving structure, wording, and presentation
+
+**Responsibilities**
+- Maintain the overall structure, presentation, and operation of the aggregated documentation
+- Must limit changes in repositories other than the documentation repository to organizational or technical adjustments (fixing syntax, restructuring folders, adapting presentation, improving wording, etc.)
+- Never alter the underlying meaning of content in other repositories without prior approval from an [approver](/contribute/contribution-process/roles/#approver) of that repository
+
+**How to become a documentation approver**
+- Obtain sponsorship from a quorum of approvers of the [documentation repository](https://github.com/gardener/documentation); nomination is initiated by one or more existing documentation approvers through a new PR.
+- Cross-repository access is granted by adding the `documentation-approvers` alias to the `/docs` `OWNERS` (or `OWNERS_ALIASES`) of each referenced repository, scoping the role to the documentation paths aggregated by docforge. An approver of the respective repository performs this change.

--- a/hugo/content/contribute/contribution-process/roles.md
+++ b/hugo/content/contribute/contribution-process/roles.md
@@ -94,11 +94,11 @@ Approvers share the requirements and responsibilities of [reviewers](#reviewer),
 
 ## Documentation Maintainer
 
-Documentation Maintainers are deeply involved in the holistic maintenance, structure, and operation of the [Gardener documentation](https://gardener.cloud/).
+Documentation maintainers are deeply involved in the holistic maintenance, structure, and operation of the [Gardener documentation](https://gardener.cloud/).
 In addition to approver permissions on the [documentation repository](https://github.com/gardener/documentation), they hold approver permissions for the `/docs` folder of every project referenced in the [docforge manifest files](https://github.com/gardener/documentation/tree/master/.docforge), which [docforge](https://github.com/gardener/docforge) aggregates into the final documentation.
 This cross-repository permission ensures smooth documentation maintenance, comparable to setups where all documentation lives in one central repository rather than being colocated with the code.
 
-Documentation Maintainers share the requirements and responsibilities of [approvers](#approver), with additional expectations:
+Documentation maintainers share the requirements and responsibilities of [approvers](#approver), with additional expectations:
 
 **Requirements**
 - Approver role on the [documentation repository](https://github.com/gardener/documentation)

--- a/hugo/content/contribute/contribution-process/roles.md
+++ b/hugo/content/contribute/contribution-process/roles.md
@@ -92,26 +92,6 @@ Approvers share the requirements and responsibilities of [reviewers](#reviewer),
 **How to become an approver**
 - Obtain sponsorship from a quorum of approvers of the target repository; nomination is initiated by one or more existing approvers through a new PR, which must receive positive reviews from the quorum.
 
-## Documentation Maintainer
-
-Documentation Maintainers are deeply involved in the holistic maintenance, structure, and operation of the [Gardener documentation](https://gardener.cloud/).
-In addition to approver permissions on the [documentation repository](https://github.com/gardener/documentation), they hold approver permissions for the `/docs` folder of every project referenced in the [docforge manifest files](https://github.com/gardener/documentation/tree/master/.docforge), which [docforge](https://github.com/gardener/docforge) aggregates into the final documentation.
-This cross-repository permission ensures smooth documentation maintenance, comparable to setups where all documentation lives in one central repository rather than being colocated with the code.
-
-Documentation Maintainers share the requirements and responsibilities of [approvers](#approver), with additional expectations:
-
-**Requirements**
-- Approver role on the [documentation repository](https://github.com/gardener/documentation)
-- Broad understanding of the Gardener documentation structure and the docforge aggregation process
-
-**Responsibilities**
-- Maintain the overall structure, presentation, and operation of the aggregated documentation
-- Limit changes in repositories other than the documentation repository to organizational or technical adjustments (fixing syntax, restructuring folders, adapting presentation, improving wording, etc.)
-- Never alter the underlying meaning of content in other repositories without prior approval from an [approver](#approver) of that repository
-
-**How to become a documentation maintainer**
-- Obtain sponsorship from a quorum of approvers of the [documentation repository](https://github.com/gardener/documentation); nomination is initiated by one or more existing approvers or documentation maintainers through a new PR.
-
 ## Adjustment of Membership Status
 
 Approvers periodically review the contents of the [`OWNERS`](https://docs.prow.k8s.io/docs/components/plugins/approve/approvers/#overview) and [`OWNERS_ALIASES`](https://docs.prow.k8s.io/docs/components/plugins/approve/approvers/#overview) files to ensure accuracy. If a reviewer or approver becomes inactive or does not fulfill the defined requirements and responsibilities, their status may be adjusted or removed. These decisions are made on a case-by-case basis and require agreement from a quorum of approvers.

--- a/hugo/content/contribute/contribution-process/roles.md
+++ b/hugo/content/contribute/contribution-process/roles.md
@@ -94,11 +94,11 @@ Approvers share the requirements and responsibilities of [reviewers](#reviewer),
 
 ## Documentation Maintainer
 
-Documentation maintainers are deeply involved in the holistic maintenance, structure, and operation of the [Gardener documentation](https://gardener.cloud/).
+Documentation Maintainers are deeply involved in the holistic maintenance, structure, and operation of the [Gardener documentation](https://gardener.cloud/).
 In addition to approver permissions on the [documentation repository](https://github.com/gardener/documentation), they hold approver permissions for the `/docs` folder of every project referenced in the [docforge manifest files](https://github.com/gardener/documentation/tree/master/.docforge), which [docforge](https://github.com/gardener/docforge) aggregates into the final documentation.
 This cross-repository permission ensures smooth documentation maintenance, comparable to setups where all documentation lives in one central repository rather than being colocated with the code.
 
-Documentation maintainers share the requirements and responsibilities of [approvers](#approver), with additional expectations:
+Documentation Maintainers share the requirements and responsibilities of [approvers](#approver), with additional expectations:
 
 **Requirements**
 - Approver role on the [documentation repository](https://github.com/gardener/documentation)

--- a/hugo/content/contribute/contribution-process/roles.md
+++ b/hugo/content/contribute/contribution-process/roles.md
@@ -92,6 +92,26 @@ Approvers share the requirements and responsibilities of [reviewers](#reviewer),
 **How to become an approver**
 - Obtain sponsorship from a quorum of approvers of the target repository; nomination is initiated by one or more existing approvers through a new PR, which must receive positive reviews from the quorum.
 
+## Documentation Maintainer
+
+Documentation Maintainers are deeply involved in the holistic maintenance, structure, and operation of the [Gardener documentation](https://gardener.cloud/).
+In addition to approver permissions on the [documentation repository](https://github.com/gardener/documentation), they hold approver permissions for the `/docs` folder of every project referenced in the [docforge manifest files](https://github.com/gardener/documentation/tree/master/.docforge), which [docforge](https://github.com/gardener/docforge) aggregates into the final documentation.
+This cross-repository permission ensures smooth documentation maintenance, comparable to setups where all documentation lives in one central repository rather than being colocated with the code.
+
+Documentation Maintainers share the requirements and responsibilities of [approvers](#approver), with additional expectations:
+
+**Requirements**
+- Approver role on the [documentation repository](https://github.com/gardener/documentation)
+- Broad understanding of the Gardener documentation structure and the docforge aggregation process
+
+**Responsibilities**
+- Maintain the overall structure, presentation, and operation of the aggregated documentation
+- Limit changes in repositories other than the documentation repository to organizational or technical adjustments (fixing syntax, restructuring folders, adapting presentation, improving wording, etc.)
+- Never alter the underlying meaning of content in other repositories without prior approval from an [approver](#approver) of that repository
+
+**How to become a documentation maintainer**
+- Obtain sponsorship from a quorum of approvers of the [documentation repository](https://github.com/gardener/documentation); nomination is initiated by one or more existing approvers or documentation maintainers through a new PR.
+
 ## Adjustment of Membership Status
 
 Approvers periodically review the contents of the [`OWNERS`](https://docs.prow.k8s.io/docs/components/plugins/approve/approvers/#overview) and [`OWNERS_ALIASES`](https://docs.prow.k8s.io/docs/components/plugins/approve/approvers/#overview) files to ensure accuracy. If a reviewer or approver becomes inactive or does not fulfill the defined requirements and responsibilities, their status may be adjusted or removed. These decisions are made on a case-by-case basis and require agreement from a quorum of approvers.

--- a/hugo/content/contribute/contribution-process/roles.md
+++ b/hugo/content/contribute/contribution-process/roles.md
@@ -26,6 +26,9 @@ Various aspects and definitions were adopted from the [Kubernetes Community memb
 > Not every Gardener subproject (repository) may have applied the listed community roles yet.
 > If adopted, this document is linked in the repository's top-level `README.md` file.
 
+The roles described here are tailored to code repositories.
+For documentation-specific contribution roles, see [Documentation Roles](/contribute/contribution-process/documentation-roles/).
+
 ## Member
 
 Members are active contributors in the Gardener community. They can have issues and PRs assigned to them, and are granted the privilege to run pre-submit tests on their own and all other PRs.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Adds the Documentation Maintainer role to the community roles doc. This role holds approver permissions on the documentation repository plus the `/docs` folders of all projects aggregated via docforge, enabling holistic documentation maintenance across repositories.

**Which issue(s) this PR fixes**:
Fixes # 

**Special notes for your reviewer**:
Section follows the existing Requirements/Responsibilities/How-to schema. Please confirm the wording matches the intended scope of the role.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Documentation Roles page outlining reviewer and approver responsibilities, requirements, permissions, and membership processes.
  * Documented cross-repository approval access and documentation paths managed through Docforge.
  * Added a link to the new Documentation Roles page from the contribution process guide.

* **New Features**
  * Added an issue form for requesting the Documentation Reviewer role, including eligibility, sponsorship, and contribution details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->