### PR TITLE
Add VelmiraS to `OWNERS_ALIASES`

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -12,6 +12,7 @@ aliases:
   - n-boshnakov
   - RadaBDimitrova
   - rfranzke
+  - VelmiraS
   documentation-approvers:
   - BoHristova
   - dimitar-kostadinov
@@ -23,6 +24,7 @@ aliases:
   - n-boshnakov
   - RadaBDimitrova
   - rfranzke
+  - VelmiraS
   gardener-technical-steering:
   - rfranzke
   - ScheererJ


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind task

**What this PR does / why we need it**:
Adding [VelmiraS](https://github.com/VelmiraS) to the `OWNERS_ALIASES` file, as she is a member of the enablement team.

**Special notes for your reviewer**:
/cc @klocke-io

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added VelmiraS as an alias for documentation reviewers and approvers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->