### PR TITLE
fix(part-managed): native files without github_repo

### DIFF
--- a/hugo/content/blog/2026/07/07-23-machine-preservation-on-failure-in-gardener.md
+++ b/hugo/content/blog/2026/07/07-23-machine-preservation-on-failure-in-gardener.md
@@ -12,7 +12,12 @@ tags:
   - autoscaling
 aliases:
   - /blog/2026/07/23/machine-preservation-on-failure-in-gardener
-managed: true
+local: true
+github_repo: 'https://github.com/gardener/documentation'
+github_subdir: hugo/content/blog/2026/07
+path_base_for_github_subdir:
+  from: content/blog/2026/07/07-23-machine-preservation-on-failure-in-gardener.md
+  to: 07-23-machine-preservation-on-failure-in-gardener.md
 ---
 
 # Machine Preservation on Failure in Gardener

--- a/post-processing/part-managed.js
+++ b/post-processing/part-managed.js
@@ -12,9 +12,10 @@ const LOCAL_PATH_ALLOWLIST = [/^_index\.md$/, /^index\.md$/];
 
 function seedClassification(fm, relativePath) {
   if (LOCAL_PATH_ALLOWLIST.some(re => re.test(relativePath))) return 'local';
-  if (typeof fm.github_repo === 'string'
+  // No github_repo means docforge never processed this file — it is native to this repo.
+  if (typeof fm.github_repo !== 'string') return 'local';
+  if (LOCAL_REPO_PATTERN.test(fm.github_repo)
       && typeof fm.github_subdir === 'string'
-      && LOCAL_REPO_PATTERN.test(fm.github_repo)
       && LOCAL_SUBDIR_PATTERN.test(fm.github_subdir)) {
     return 'local';
   }


### PR DESCRIPTION
What this PR does / why we need it:

post-processing/part-managed.js classified native blog posts (files committed directly to this repo, never processed by docforge) as managed: true instead of local: true. This broke the "Edit this page" button — it pointed to an upstream repo instead of the correct location in gardener/documentation.

Root cause: seedClassification only returned 'local' for files matching LOCAL_SUBDIR_PATTERN (website/...) or LOCAL_PATH_ALLOWLIST. Files without a github_repo field fell through to return 'managed'.

Fix: add an early return — if github_repo is absent, docforge never processed the file, so it is native to this repo and must be local: true.

Also corrects the existing misclassification of hugo/content/blog/2026/07/07-23-machine-preservation-on-failure-in-gardener.md, which was marked managed: true by a previous run of the unfixed script.

Which issue(s) this PR fixes:
Fixes #

Special notes for your reviewer:

The seedClassification change affects only files that have no local/managed marker yet (new files). Existing correctly-classified files are not re-evaluated. The data fix for the 07-23 blog post is a one-time correction for an already-misclassified file — future native blog posts will be classified correctly from the first script run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file classification for entries without a valid repository identifier.
  * Ensured repository and subdirectory metadata are both matched before files are classified as local.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->