### PR TITLE
Introduce optional threat modeling for security-related topics.

### DIFF
--- a/hugo/content/community/steering/index.md
+++ b/hugo/content/community/steering/index.md
@@ -109,6 +109,7 @@ Once your PR is open:
 - The proposal is first **reviewed asynchronously** by the committee via the Pull Request:
   - Steering committee members review the document and leave questions or comments **directly in the PR review**.
   - The goal of this phase is to clarify open questions and address smaller issues before the meeting.
+  - If the proposal touches security-related topics a [threat modeling](https://owasp.org/www-community/Threat_Modeling) may need to be conducted. The decision whether this is required is at the discretion of the TSC.
 - Once feedback from a **majority of the committee** (typically 3 out of 4 members) has been provided, a steering meeting is scheduled.
   - A [TSC meeting](#-meeting-process) is picked from the **recurring Thursday slot** (10:00–11:00 Europe/Berlin), usually about **two weeks out** to allow for review ping-pong and for incorporating feedback into the document.
 - The meeting will be **announced** to the community via our [`#gardener`](https://gardener-cloud.slack.com/archives/C045DSWJZB9) Slack channel and in the public meeting agenda. If no proposal is scheduled for a given Thursday, the meeting for that week is **canceled**.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

Introduce optional [threat modeling](https://owasp.org/www-community/Threat_Modeling) for security-related topics.

As discussed and agreed in the technical steering committee meeting on August 13th, proposals touching security-related areas, e.g. credentials or authentication/authorisation, may need an additional round of vetting for security risks.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/cc @rfranzke @vpnachev @timebertt