### PR TITLE
Fix copyright text: remove redundant Copyright prefix

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation_reviewer_role.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation_reviewer_role.yaml
@@ -1,4 +1,4 @@
-# Modifications Copyright Copyright Contributors to the Gardener project.
+# Modifications Copyright Contributors to the Gardener project.
 name: Documentation Reviewer Role Request
 description: Request the documentation reviewer role
 labels: ["kind/task"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# SPDX-FileCopyrightText: Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -6,11 +6,11 @@ SPDX-PackageDownloadLocation = "https://github.com/gardener/documentation"
 [[annotations]]
 path = "**"
 precedence = "aggregate"
-SPDX-FileCopyrightText = "Copyright Contributors to the Gardener project"
+SPDX-FileCopyrightText = "Contributors to the Gardener project"
 SPDX-License-Identifier = "CC-BY-4.0"
 
 [[annotations]]
 path = ["Makefile", "scripts/**", "website/installer/**", ".ci/**"]
 precedence = "aggregate"
-SPDX-FileCopyrightText = "Copyright Contributors to the Gardener project"
+SPDX-FileCopyrightText = "Contributors to the Gardener project"
 SPDX-License-Identifier = "Apache-2.0"


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the copyright text introduced in the previous PR - removes the redundant "Copyright" prefix so the text reads "Contributors to the Gardener project" instead of "Copyright Contributors to the Gardener project".

**Which issue(s) this PR fixes**:
Follow-up to the copyright text update.

**Special notes for your reviewer**:

**Release note**:
```other operator
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected copyright and SPDX attribution wording across project documentation and metadata.
  * Removed duplicated wording while preserving existing license identifiers and annotation paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->