### PR TITLE
Adapt to NeoNephos changes

### DIFF
--- a/hugo/content/contribute/contribution-process/pr-guidelines.md
+++ b/hugo/content/contribute/contribution-process/pr-guidelines.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - /docs/contribute/documentation/pr-description
-  - /docs/contribute/documentation/pr-guidelines/
+  - /docs/contribute/code/pr-description
+  - /docs/contribute/code/pr-guidelines/
 title: Pull Request Creation Guidelines
 prev: false
 next: false
@@ -51,7 +51,7 @@ When writing a commit message or a PR title, consider the following guidelines:
   ```
 
   > [!IMPORTANT]
-  > All commits must have a `Signed-off-by` trailer from the author. For more information, visit the [Git documentation](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) and our [Contributor Guide](../contributor-guide/#developer-certificate-of-origin).
+  > All commits must have a `Signed-off-by` trailer from the author. For more information, visit the [Git documentation](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) and our [Contributor Guide](./contributor-guide/#developer-certificate-of-origin).
 
 - Follow the [Formatting of Inline Elements guide](/contribute/documentation/formatting-guide/#formatting-of-inline-elements):
   

--- a/hugo/content/contribute/contribution-process/roles.md
+++ b/hugo/content/contribute/contribution-process/roles.md
@@ -42,7 +42,7 @@ Members are active contributors in the Gardener community. They can have issues 
 Technically, members are defined by their membership in the [Gardener GitHub org](https://github.com/gardener).
 
 **Requirements**
-- Demonstrate stake and long-term commitment in the Gardener project, e.g., through previous code contributions or company affiliation
+- Demonstrate stake and long-term commitment in the Gardener project, e.g., through previous code contributions or [NeoNephos membership](https://neonephos.org/members) affiliation
 - Maintained GitHub profile to make yourself known to other project maintainers
 - Enabled GitHub notifications for their ongoing PR reviews and issues
 

--- a/hugo/content/contribute/documentation/pr-guidelines.md
+++ b/hugo/content/contribute/documentation/pr-guidelines.md
@@ -50,6 +50,9 @@ When writing a commit message or a PR title, consider the following guidelines:
   Fixed the super important issue
   ```
 
+  > [!IMPORTANT]
+  > All commits must have a `Signed-off-by` trailer from the author. For more information visit the [Git documentation](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s).
+
 - Follow the [Formatting of Inline Elements guide](/contribute/documentation/formatting-guide/#formatting-of-inline-elements):
   
   Use

--- a/hugo/content/contribute/documentation/pr-guidelines.md
+++ b/hugo/content/contribute/documentation/pr-guidelines.md
@@ -51,7 +51,7 @@ When writing a commit message or a PR title, consider the following guidelines:
   ```
 
   > [!IMPORTANT]
-  > All commits must have a `Signed-off-by` trailer from the author. For more information visit the [Git documentation](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s).
+  > All commits must have a `Signed-off-by` trailer from the author. For more information, visit the [Git documentation](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) and our [Contributor Guide](../contributor-guide/#developer-certificate-of-origin).
 
 - Follow the [Formatting of Inline Elements guide](/contribute/documentation/formatting-guide/#formatting-of-inline-elements):
   


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
1. Clarify company affiliation after Gardener has been donated to NeoNephos.
2. Add `Signed-off-by` requirement in PR creation guide. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @marc1404 