### PR TITLE
Add `status` documentation to the "Developer Starter Kit" section

### DIFF
--- a/.docforge/contribute.yaml
+++ b/.docforge/contribute.yaml
@@ -35,6 +35,7 @@ structure:
       source: https://github.com/gardener/gardener/blob/master/docs/development/changing-the-api.md
     - file: status.md
       frontmatter:
+        title: Status Subresource
         weight: 90
       source: https://github.com/gardener/gardener/blob/master/docs/development/status.md
     - file: defaulting.md

--- a/.docforge/contribute.yaml
+++ b/.docforge/contribute.yaml
@@ -33,13 +33,17 @@ structure:
       frontmatter:
         weight: 80
       source: https://github.com/gardener/gardener/blob/master/docs/development/changing-the-api.md
-    - file: defaulting.md
+    - file: status.md
       frontmatter:
         weight: 90
+      source: https://github.com/gardener/gardener/blob/master/docs/development/status.md
+    - file: defaulting.md
+      frontmatter:
+        weight: 100
       source: https://github.com/gardener/gardener/blob/master/docs/development/defaulting.md
     - file: validation-guidelines.md
       frontmatter:
-        weight: 100
+        weight: 110
       source: https://github.com/gardener/gardener/blob/master/docs/development/validation-guidelines.md
 
   - dir: gardener
@@ -56,6 +60,7 @@ structure:
         - validation-guidelines.md
         - ipv6.md
         - changing-the-api.md
+        - status.md
         - defaulting.md
         - kubernetes-clients.md
         - logging-guidelines.md


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

The PR moves the recently created documentation for the `status` subresource to the [Developer Starter Kit](https://gardener.cloud/contribute/developer-starter-kit/) section, as it is relevant to all code contributions, not just those related to Gardener Core.

**Special notes for your reviewer**:
/cc @timuthy @marc1404 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new “Status Subresource” topic to the developer starter kit documentation.
  * Reordered related documentation topics for improved navigation.
  * Excluded the new topic from the Gardener development documentation file tree.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->