### PR TITLE
feat(ci): guard against self-referencing frontmatter

### DIFF
--- a/.github/workflows/check-frontmatter.yml
+++ b/.github/workflows/check-frontmatter.yml
@@ -1,0 +1,41 @@
+name: Check Frontmatter
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'hugo/content/**/*.md'
+      - 'post-processing/check-frontmatter.js'
+      - 'post-processing/lib/selfref.js'
+      - '.github/workflows/check-frontmatter.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Block self-referencing frontmatter
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24
+
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Check frontmatter for self-references
+        run: node post-processing/check-frontmatter.js

--- a/post-processing/check-frontmatter.js
+++ b/post-processing/check-frontmatter.js
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+// CI check: scans all markdown files under hugo/content/ and fails (exit 1) when
+// a file's frontmatter misclassifies local content as aggregated.
+//
+// It catches two cases (see lib/selfref.js):
+//  - github_repo pointing at gardener/documentation itself (self-reference)
+//  - local: true combined with github_repo (contradictory)
+//
+// This guards against the class of bug where a locally committed file (e.g.
+// hugo/content/community/hackathons/2026-11.md) gets a self-referencing
+// github_repo injected and is then wrongly treated as a read-only MANAGED file.
+
+import { readdirSync } from 'fs';
+import path from 'path';
+import process from 'process';
+
+import { read } from './lib/frontmatter.js';
+import { findViolations } from './lib/selfref.js';
+
+const CONTENT_DIR = path.resolve(process.cwd(), 'hugo/content');
+
+// Recursively collects every *.md file below dir.
+function collectMarkdown(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...collectMarkdown(full));
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function main() {
+  let files;
+  try {
+    files = collectMarkdown(CONTENT_DIR);
+  } catch (err) {
+    console.error(`check-frontmatter: cannot scan ${CONTENT_DIR}: ${err.message}`);
+    process.exit(2);
+  }
+
+  const violations = [];
+  for (const file of files) {
+    let data;
+    try {
+      ({ data } = read(file));
+    } catch (err) {
+      // A parse failure is itself a problem worth surfacing, but keep it
+      // distinct from a clean check so CI logs point at the offending file.
+      console.error(`check-frontmatter: ${err.message}`);
+      process.exit(2);
+    }
+    violations.push(...findViolations(path.relative(process.cwd(), file), data));
+  }
+
+  if (violations.length > 0) {
+    console.error('\nMisclassified frontmatter detected:\n');
+    for (const v of violations) {
+      console.error(`  ${v.file}`);
+      console.error(`    [${v.rule}] ${v.message}\n`);
+    }
+    console.error(
+      'These files are local content but are tagged as aggregated from upstream.',
+    );
+    console.error(
+      'Remove the offending github_repo (and any contradictory local: true) so the',
+    );
+    console.error('banner step classifies them as LOCAL.\n');
+    process.exit(1);
+  }
+
+  console.log(`check-frontmatter: ${files.length} files OK, no self-references.`);
+}
+
+main();

--- a/post-processing/lib/selfref.js
+++ b/post-processing/lib/selfref.js
@@ -1,0 +1,53 @@
+// Detects frontmatter that misclassifies local content as managed.
+//
+// Background: docforge aggregates upstream markdown into hugo/content/ and marks
+// each file with `github_repo` pointing at its upstream source. The banner
+// classifier (see banner.js) treats any file with `github_repo` as MANAGED.
+//
+// A file whose `github_repo` points at gardener/documentation itself is a
+// self-reference: real upstream content never lives in the documentation repo,
+// so such a value almost certainly means locally maintained content was
+// accidentally tagged as aggregated. That file then gets a MANAGED banner and
+// is treated as read-only, even though it is the source of truth.
+
+// Matches https://github.com/gardener/documentation with optional scheme,
+// trailing slash or .git suffix, case-insensitive. Only the exact repo counts;
+// e.g. gardener/documentation-foo must not match.
+const SELF_REPO_RE =
+  /^(?:https?:\/\/)?github\.com\/gardener\/documentation(?:\.git)?\/?$/i;
+
+// Returns true if github_repo points at the documentation repo itself.
+export function isSelfReference(githubRepo) {
+  if (typeof githubRepo !== 'string') return false;
+  return SELF_REPO_RE.test(githubRepo.trim());
+}
+
+// Inspects a single file's parsed frontmatter and returns a list of violation
+// objects. Empty array means the file is fine.
+//
+// Two independent checks:
+//  - self-reference: github_repo points at gardener/documentation
+//  - contradiction: `local: true` combined with any `github_repo`, which asserts
+//    both "source of truth" and "aggregated from upstream" at the same time
+export function findViolations(filePath, data) {
+  const violations = [];
+  const githubRepo = data?.github_repo;
+
+  if (isSelfReference(githubRepo)) {
+    violations.push({
+      file: filePath,
+      rule: 'self-reference',
+      message: `github_repo points at gardener/documentation itself (${githubRepo}); local content must not be tagged as aggregated`,
+    });
+  }
+
+  if (data?.local === true && typeof githubRepo === 'string') {
+    violations.push({
+      file: filePath,
+      rule: 'local-and-github_repo',
+      message: `frontmatter sets local: true and github_repo (${githubRepo}) at the same time; a file is either local or aggregated, not both`,
+    });
+  }
+
+  return violations;
+}

--- a/post-processing/lib/selfref.test.js
+++ b/post-processing/lib/selfref.test.js
@@ -1,0 +1,86 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { isSelfReference, findViolations } from './selfref.js';
+
+// --- isSelfReference ---
+
+test('isSelfReference: canonical https url -> true', () => {
+  assert.equal(isSelfReference('https://github.com/gardener/documentation'), true);
+});
+
+test('isSelfReference: trailing slash tolerated', () => {
+  assert.equal(isSelfReference('https://github.com/gardener/documentation/'), true);
+});
+
+test('isSelfReference: .git suffix tolerated', () => {
+  assert.equal(isSelfReference('https://github.com/gardener/documentation.git'), true);
+});
+
+test('isSelfReference: schemeless form -> true', () => {
+  assert.equal(isSelfReference('github.com/gardener/documentation'), true);
+});
+
+test('isSelfReference: surrounding whitespace tolerated', () => {
+  assert.equal(isSelfReference('  https://github.com/gardener/documentation  '), true);
+});
+
+test('isSelfReference: real upstream repo -> false', () => {
+  assert.equal(isSelfReference('https://github.com/gardener/gardener'), false);
+});
+
+test('isSelfReference: lookalike repo name -> false', () => {
+  assert.equal(isSelfReference('https://github.com/gardener/documentation-foo'), false);
+});
+
+test('isSelfReference: different org -> false', () => {
+  assert.equal(isSelfReference('https://github.com/other/documentation'), false);
+});
+
+test('isSelfReference: non-string -> false', () => {
+  assert.equal(isSelfReference(undefined), false);
+  assert.equal(isSelfReference(null), false);
+});
+
+// --- findViolations ---
+
+test('findViolations: clean upstream file -> no violations', () => {
+  const data = { github_repo: 'https://github.com/gardener/gardener' };
+  assert.deepEqual(findViolations('a.md', data), []);
+});
+
+test('findViolations: clean local file -> no violations', () => {
+  const data = { title: 'Overview', local: true };
+  assert.deepEqual(findViolations('a.md', data), []);
+});
+
+test('findViolations: self-reference is flagged', () => {
+  const data = { github_repo: 'https://github.com/gardener/documentation' };
+  const out = findViolations('a.md', data);
+  assert.equal(out.length, 1);
+  assert.equal(out[0].rule, 'self-reference');
+  assert.equal(out[0].file, 'a.md');
+});
+
+test('findViolations: local: true plus github_repo is flagged', () => {
+  const data = { local: true, github_repo: 'https://github.com/gardener/gardener' };
+  const out = findViolations('a.md', data);
+  assert.equal(out.length, 1);
+  assert.equal(out[0].rule, 'local-and-github_repo');
+});
+
+test('findViolations: the 2026-11.md case trips both rules', () => {
+  // Reproduces the real bug: self-reference AND local: true together.
+  const data = {
+    github_repo: 'https://github.com/gardener/documentation',
+    local: true,
+    title: 'November 2026',
+  };
+  const out = findViolations('hugo/content/community/hackathons/2026-11.md', data);
+  const rules = out.map((v) => v.rule).sort();
+  assert.deepEqual(rules, ['local-and-github_repo', 'self-reference']);
+});
+
+test('findViolations: missing frontmatter object -> no violations', () => {
+  assert.deepEqual(findViolations('a.md', undefined), []);
+});


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**

/kind bug
/kind enhancement

**What this PR does / why we need it**:

This is a **proposal** for a CI check that prevents a class of frontmatter misclassification bug.

**The problem**: docforge aggregates upstream markdown into `hugo/content/` and tags each file with `github_repo`. The banner step (`post-processing/lib/banner.js` -> `classify`) treats any file with `github_repo` as MANAGED (read-only, overwritten nightly). Files without it are LOCAL (source of truth).

A file whose `github_repo` points at `github.com/gardener/documentation` itself is a **self-reference**. Real upstream content never lives in the documentation repo, so such a value almost certainly means locally maintained content was accidentally tagged as aggregated. It then gets a MANAGED banner despite being the source of truth, and it is in no docforge manifest.

**Concrete example**: `hugo/content/community/hackathons/2026-11.md` was committed locally, then a later aggregation run injected `github_repo: 'https://github.com/gardener/documentation'`. It ended up wrongly classified as MANAGED, and contradictorily carried both `local: true` and a MANAGED banner.

**What the check does**:
- New `post-processing/lib/selfref.js`: `isSelfReference()` + `findViolations()`, flagging
  1. `github_repo` pointing at `gardener/documentation` (self-reference)
  2. `local: true` combined with any `github_repo` (contradictory)
- New `post-processing/check-frontmatter.js`: scans every `*.md` under `hugo/content/`, uses the existing `lib/frontmatter.js` `read()`, exits 1 on violations.
- New `.github/workflows/check-frontmatter.yml`: runs the check on content PRs (mirrors `enforce-managed-files.yml` style, pinned action SHAs).
- Unit tests in `post-processing/lib/selfref.test.js` (node:test, assert/strict) following the existing `lib/*.test.js` style.

**Special notes for your reviewer**:

- This PR intentionally does **not** fix `2026-11.md` (handled separately). Running the check on `master` currently fails on exactly that file, which demonstrates it catches the real bug.
- `node --test post-processing/lib/selfref.test.js` -> 15/15 pass.
- Proposal: open for discussion on whether the self-reference regex and the two rules match your intent.