### PR TITLE
Improve post-processing: GENERATED banners, cleanup, image path capturing

### DIFF
--- a/.github/workflows/aggregate-content.yml
+++ b/.github/workflows/aggregate-content.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Install deps
         run: make ci-install
 
+      - name: Remove managed banner files
+        run: ./delete-managed-banner.sh --force hugo/content
+
       # Docforge primarily reads via raw.githubusercontent.com which does not
       # consume GitHub API rate limits. The default GITHUB_TOKEN authenticates
       # the smaller number of metadata API calls.

--- a/CONTENT_AGGREGATION.md
+++ b/CONTENT_AGGREGATION.md
@@ -1,0 +1,241 @@
+# Content Aggregation
+
+This document explains how the Gardener documentation site assembles its content: the
+distributed model behind it, the file lifecycle, the post-processing pipeline, and why
+aggregation runs asynchronously instead of during the build. If you only want to *make a
+change*, the [README](README.md) is enough — read this when you need to understand *why*
+things are shaped the way they are.
+
+## The distributed documentation model
+
+Gardener is not one repository. The product is spread across dozens of repos
+(`gardener/gardener`, `gardener/dashboard`, `gardener/gardenctl-v2`, extensions, and more),
+and each one owns its own documentation next to its code. This repository **aggregates**
+those docs into a single site and bundles in some general documentation of its own.
+
+Keeping docs next to the code they describe means:
+
+- **One source of truth.** A doc is edited where its code lives; there is no divergent
+  second copy to keep in sync.
+- **Docs ship with the code.** A feature PR and its documentation land in the same repo,
+  reviewed by the same people who understand the change.
+- **The site stays fresh automatically.** A scheduled job re-pulls every source, so
+  upstream edits appear here without anyone touching this repository.
+
+## Mental model
+
+All docs live in `hugo/content/`. Some are **local** (blog, about, community, landing page)
+and some are **aggregated** from upstream repositories. The aggregated documentation folder
+structure is defined by manifests in `.docforge/*.yaml` and run through docforge in CI on a
+daily schedule. The resulting tree is **committed to `master` only if the newly aggregated
+files still build**. If the build fails, a PR is opened instead so the new content can be
+fixed and merged asynchronously. This keeps `master` always publishable.
+
+```mermaid
+graph LR
+    U["Upstream repos<br/>gardener/gardener<br/>dashboard, gardenctl-v2, ..."] -->|docforge reads| AGG
+    M[".docforge/*.yaml<br/>manifests"] -->|define| AGG["Aggregation<br/>(runs in CI)"]
+    L["Local files<br/>blog, about,<br/>community, index"] -->|kept in place| AGG
+    AGG --> BUILD{"build<br/>passes?"}
+    BUILD -->|yes| C["commit to master<br/>hugo/content/"]
+    BUILD -->|no| PRPATH["open a PR<br/>master untouched"]
+    C -->|srcDir| V["VitePress build"]
+```
+
+Two things to internalize:
+
+- **Aggregation happens in CI, not on your machine.** A nightly job and any push to
+  `.docforge/**` regenerate `hugo/content/` and commit it when the build passes (see
+  [How a bad upstream change is kept off `master`](#how-a-bad-upstream-change-is-kept-off-master)).
+  See [.github/workflows/aggregate-content.yml](.github/workflows/aggregate-content.yml).
+- **`hugo/` is a legacy directory name.** The site runs on VitePress; `srcDir` points at
+  `hugo/content/` for historical reasons. There is no Hugo in the build.
+
+## Ownership: who owns which file
+
+Every markdown file in `hugo/content/` carries exactly **one banner** as an HTML comment
+right after its frontmatter. The banner is injected during post-processing
+([post-processing/part-banner.js](post-processing/part-banner.js)) and is the visible
+signal for who owns the file. Classification is derived from frontmatter, not from a
+hand-set `local:`/`managed:` flag.
+
+```mermaid
+graph TD
+    F["A .md file in hugo/content/"] --> Q1{"github_repo<br/>in frontmatter?"}
+    Q1 -->|yes| MG["MANAGED<br/>&lt;!-- BANNER:MANAGED --&gt;"]
+    Q1 -->|no| Q2{"auto_generated:<br/>true?"}
+    Q2 -->|yes| GN["GENERATED<br/>&lt;!-- BANNER:GENERATED --&gt;"]
+    Q2 -->|no| LO["LOCAL<br/>&lt;!-- BANNER:LOCAL --&gt;"]
+```
+
+| Banner | Derived from | Source of truth | Edit here? |
+|---|---|---|---|
+| `MANAGED` | `github_repo` in frontmatter | the upstream repo | **No.** The nightly run overwrites it. The banner itself prints the exact upstream URL — open a PR there. |
+| `LOCAL` | no `github_repo` | this repository | **Yes.** Edit directly under `hugo/content/`. |
+| `GENERATED` | `auto_generated: true` | [part-index.js](post-processing/part-index.js) | **No.** It is a navigation stub, recreated on every run. |
+
+A CI check ([enforce-managed-files.yml](.github/workflows/enforce-managed-files.yml))
+runs [hack/check-managed.mjs](hack/check-managed.mjs) and **blocks any PR that touches a
+MANAGED file**, because such edits would be silently lost on the next aggregation.
+
+### What the banners look like
+
+Each banner is an HTML comment (invisible in the rendered site) sitting directly after the
+frontmatter. Open any file and you can tell at a glance who owns it.
+
+**MANAGED** — the banner ends with the exact upstream URL to open your PR against. It is
+derived from `github_repo` + `github_subdir` in the frontmatter, so you never have to
+reconstruct the path yourself. Example from `hugo/content/docs/gardener/managed_seed.md`:
+
+```markdown
+<!-- BANNER:MANAGED -->
+<!--
+   █▀▀ ▀█▀ █▀█ █▀█
+   ▀▀█  █  █ █ █▀▀
+   ▀▀▀  ▀  ▀▀▀ ▀
+
+   ┌────────────────────────────────────────────────┐
+   │  MANAGED FILE — aggregated from upstream       │
+   │                                                │
+   │  Editing here is pointless: The nightly        │
+   │  aggregation run overwrites this file.         │
+   │                                                │
+   │  Open a PR against the source instead: ─────┐  │
+   │                          ┌──┐    ┌──────────┘  │
+   │                          └──│────┘             │
+   │           ┌─────────────────┘                  │
+   └───────────│────────────────────────────────────┘
+               ▼               
+   https://github.com/gardener/gardener/blob/master/docs/operations/managed_seed.md
+-->
+```
+
+**LOCAL** — no `github_repo`, so it is maintained here. Example from a blog post:
+
+```markdown
+<!-- BANNER:LOCAL -->
+<!--
+   █▀█ █▄▀
+   █ █ █▀▄
+   ▀▀▀ ▀ ▀
+
+   ┌────────────────────────────────────────────────┐
+   │  LOCAL FILE — maintained in gardener/          │
+   │  documentation.                                │
+   │                                                │
+   │  Go ahead and edit this file directly.         │
+   │  Changes here are the source of truth.         │
+   └────────────────────────────────────────────────┘
+-->
+```
+
+**GENERATED** — a navigation stub created by post-processing, no upstream source. Example
+from `hugo/content/docs/other-components/etcd-druid/deployment/index.md`:
+
+```markdown
+<!-- BANNER:GENERATED -->
+<!--
+   █▀▀ █▀▀ █▄ █
+   █ █ █▀▀ █ ▀█
+   ▀▀▀ ▀▀▀ ▀  ▀
+
+   ┌────────────────────────────────────────────────┐
+   │  GENERATED FILE — navigation stub              │
+   │                                                │
+   │  Created by post-processing/part-index.js      │
+   │  (addMissingIndexFiles). It has no upstream    │
+   │  source; the aggregation run recreates it.     │
+   │                                                │
+   │  Do not edit and do not commit by hand.        │
+   └────────────────────────────────────────────────┘
+-->
+```
+
+## The aggregation pipeline
+
+Aggregation is a strict pipeline. **Order matters** — running the steps out of order
+produces ghost pages or an inconsistent tree.
+
+```mermaid
+graph TD
+    R["delete-managed-banner.sh --force<br/>deletes all MANAGED + GENERATED files"] --> D
+    D["docforge-ci"] --> P
+    subgraph P["make post-process"]
+      P1["part-1: rename images, add h1,<br/>youtube, fix network doc"] --> P2
+      P2["part-2: migrate alerts, clean layouts,<br/>flatten dirs, nav frontmatter"] --> PI
+      PI["part-index: _index.md → index.md,<br/>create missing index stubs"] --> PB
+      PB["part-banner: inject<br/>MANAGED / LOCAL / GENERATED"] --> P3
+      P3["part-3: update report link,<br/>process api html"]
+    end
+    P3 --> B["make build (VitePress)"]
+```
+
+Why each piece exists:
+
+- **`delete-managed-banner.sh` runs first.** docforge writes purely additively and never
+  deletes. If an entry is removed from a `.docforge/` manifest, its previously generated
+  files would linger as ghost pages. Wiping all MANAGED + GENERATED files before each run
+  clears those orphans while leaving LOCAL files untouched.
+- **docforge** pulls the markdown from upstream repos as defined by the manifests
+  ([.docforge/hugo.yaml](.docforge/hugo.yaml) and the files it includes).
+- **post-process** ([Makefile](Makefile) target `post-process`) bridges the aggregated
+  output to what VitePress renders: it normalizes directory indexes to `index.md`, injects
+  the ownership banners, and translates legacy shortcode/frontmatter conventions. Never
+  leave a bare docforge run without post-process — the tree would be half-migrated.
+
+The whole pipeline is codified in the CI workflow and mirrored by the `make hugo-refresh`
+target for local manifest testing.
+
+## Why aggregation is asynchronous
+
+Aggregation used to run **inside the build**. The repository kept two separate trees:
+
+- **`website/`** — the local, hand-authored source (blog, about, community, landing page,
+  and the docforge manifests).
+- **`hugo/`** — the docforge **output**. It was **not committed**. Every `make local-preview`
+  did `rm -rf hugo`, then ran docforge to pull upstream content, post-processed it, and
+  built the site from the freshly generated tree.
+
+That coupling caused several problems:
+
+- Every build, and every contributor who wanted to test something, needed a
+  `GITHUB_OAUTH_TOKEN` and a local docforge binary.
+- A local preview took nearly two minutes because it re-aggregated `hugo/content/` from
+  scratch every time — a full rebuild was always necessary to move new content from
+  `website/` into `hugo/content/`, where VitePress then picked it up.
+- Builds broke unpredictably when an upstream repo introduced syntax docforge or VitePress
+  could not handle, or when GitHub rate-limited / cache-missed the aggregation.
+- Local edits to content did not take effect until the whole re-aggregation ran.
+
+docforge now runs once per night in a
+GitHub Action, post-processes, and **commits the result**. The build simply reads the
+committed tree. Once the build no longer generated `hugo/`, a separate
+`website/` tree bought nothing it was just a second copy of the local files that had to be
+merged into the aggregated tree anyway. So `website/` was dropped and its local files moved
+**into** `hugo/content/`, alongside the aggregated ones, distinguished by their ownership
+banner rather than by folder.
+
+The payoff:
+
+- **No token, no docforge needed to build.** The tree is already there, so there is no
+  initial setup to contribute or test.
+- **Local edits are instant.** VitePress hot reload picks up local content changes under
+  `make dev` in seconds, with no aggregation on the critical path and no full rebuild.
+
+### How a bad upstream change is kept off `master`
+
+Because aggregation is asynchronous, a broken upstream source cannot break an unrelated
+contributor's build. The nightly job
+([aggregate-content.yml](.github/workflows/aggregate-content.yml)) guards `master`:
+
+```mermaid
+graph TD
+    N["Nightly job: docforge + post-process"] --> B{"make build<br/>succeeds?"}
+    B -->|yes| PUSH["commit + push to master"]
+    B -->|no| PR["open a PR with the broken tree<br/>master stays untouched"]
+```
+
+The job builds the freshly aggregated tree and **only pushes to `master` if the build
+succeeds**. On failure, it opens a pull request containing the broken tree instead of
+touching `master`. So a syntax error introduced upstream surfaces as a reviewable PR, not
+as a red build for the next person who opens an unrelated documentation PR.

--- a/CONTENT_AGGREGATION.md
+++ b/CONTENT_AGGREGATION.md
@@ -45,7 +45,7 @@ graph LR
 Two things to internalize:
 
 - **Aggregation happens in CI, not on your machine.** A nightly job and any push to
-  `.docforge/**` regenerate `hugo/content/` and commit it when the build passes (see
+  `master` that changes `.docforge/**` regenerate `hugo/content/` and commit it when the build passes (see
   [How a bad upstream change is kept off `master`](#how-a-bad-upstream-change-is-kept-off-master)).
   See [.github/workflows/aggregate-content.yml](.github/workflows/aggregate-content.yml).
 - **`hugo/` is a legacy directory name.** The site runs on VitePress; `srcDir` points at

--- a/Makefile
+++ b/Makefile
@@ -135,8 +135,10 @@ dev:
 hugo-refresh: ## Refresh md files from external repos (.docforge/), post-process, then local preview
 	@echo "Refreshing md files from external repositories, defined in .docforge/ dir."
 	@echo "USE THIS ONLY FOR TESTING OF MANIFEST CHANGES"
+	./delete-managed-banner.sh --force hugo/content
 	@$(MAKE) docforge-ci
 	@$(MAKE) post-process
+	git add hugo/content
 
 .PHONY: local-preview
 local-preview:
@@ -192,10 +194,14 @@ ci-build-preview: ## Netlify deploy-preview: full rebuild only if .docforge/ cha
 	@BASE="$${CACHED_COMMIT_REF:-origin/master}"; \
 	if ! git rev-parse --verify -q "$$BASE^{commit}" >/dev/null; then \
 		echo "Base ref '$$BASE' not resolvable (shallow clone?) -> full rebuild"; \
-		$(MAKE) ci-install docforge-ci post-process build; \
+		$(MAKE) ci-install; \
+		./delete-managed-banner.sh --force hugo/content; \
+		$(MAKE) docforge-ci post-process build; \
 	elif git diff --name-only "$$BASE...HEAD" | grep -q '^\.docforge/'; then \
 		echo "Manifest changed since $$BASE -> docforge + post-process + build"; \
-		$(MAKE) ci-install docforge-ci post-process build; \
+		$(MAKE) ci-install; \
+		./delete-managed-banner.sh --force hugo/content; \
+		$(MAKE) docforge-ci post-process build; \
 	else \
 		echo "No manifest change since $$BASE -> build only"; \
 		$(MAKE) ci-install build; \

--- a/Makefile
+++ b/Makefile
@@ -131,13 +131,12 @@ dev:
 	@$(MAKE) install
 	pnpm exec vitepress dev
 
-.PHONY: full-refresh
-full-refresh: ## Refresh md files from external repos (.docforge/), post-process, then local preview
+.PHONY: hugo-refresh
+hugo-refresh: ## Refresh md files from external repos (.docforge/), post-process, then local preview
 	@echo "Refreshing md files from external repositories, defined in .docforge/ dir."
 	@echo "USE THIS ONLY FOR TESTING OF MANIFEST CHANGES"
 	@$(MAKE) docforge-ci
 	@$(MAKE) post-process
-	@$(MAKE) local-preview
 
 .PHONY: local-preview
 local-preview:

--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ dev:
 	pnpm exec vitepress dev
 
 .PHONY: hugo-refresh
-hugo-refresh: ## Refresh md files from external repos (.docforge/), post-process, then local preview
+hugo-refresh: ## Refresh md files from external repos (.docforge/), post-process, then stage regenerated content
 	@echo "Refreshing md files from external repositories, defined in .docforge/ dir."
 	@echo "USE THIS ONLY FOR TESTING OF MANIFEST CHANGES"
 	./delete-managed-banner.sh --force hugo/content

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # 🌱 Gardener Documentation
 
-## 🚀 Quick Start
+This repository builds the Gardener documentation site with [VitePress](https://vitepress.dev/).
+Most content is **not authored here**: it is aggregated from many upstream repositories
+into `hugo/content/` and committed to `master`. For the full picture of how that works and
+why, see [CONTENT_AGGREGATION.md](CONTENT_AGGREGATION.md). This README covers what you need
+to run the site and make a change.
 
-Ready to jump in? Follow these steps to get the Gardener documentation running locally:
+## 🚀 Quick Start
 
 ### Prerequisites
 
@@ -21,78 +25,98 @@ Ready to jump in? Follow these steps to get the Gardener documentation running l
 
   Corepack picks up the pinned pnpm version from `package.json` automatically.
 
-### Steps
-
-1. Build and run a Docker container:
+### Run it
 
 ```shell
 make docker-preview
 ```
 
-2. Visit [http://localhost:5173](http://localhost:5173) in your browser! 🎉
+Then visit [http://localhost:5173](http://localhost:5173). 🎉
 
-## 📚 Understanding the Documentation Structure
+For a native run without Docker use `make dev` (dev server with hot reload) or
+`make local-preview` (production build, then preview).
 
-The Gardener documentation uses a **distributed documentation model** where content is gathered from multiple repositories into `hugo/content/` by a scheduled CI job (docforge). The aggregated tree is committed to `master`, so local builds and PRs work against `hugo/content/` directly without running docforge.
+## 📂 Content in a nutshell
 
-### Key Locations
+All docs live in `hugo/content/`. Three kinds of file share that tree, told apart by a
+banner comment that post-processing injects at the top of each file:
 
-All content lives in the committed `hugo/content/` tree. Every markdown file carries exactly one frontmatter marker that tells you who owns it:
+| Banner | Meaning | Edit here? |
+|---|---|---|
+| `LOCAL` | maintained in this repo (blog, about, community, landing page) | **Yes.** Edit directly. |
+| `MANAGED` | aggregated from an upstream repo (has `github_repo` frontmatter) | **No.** Open a PR at the upstream source; the banner prints its URL. CI blocks edits here. |
+| `GENERATED` | navigation stub created by post-processing | **No.** Recreated on every run. |
 
-- **`local: true`** — locally maintained. Edit these files directly here in `gardener/documentation`.
-  - `hugo/content/blog/` - Blog posts
-  - `hugo/content/community/` - Community-related content
-  - `hugo/content/about/` - About pages
-  - `hugo/content/index.md` - Landing page
-  - `hugo/content/public/` - Static assets (favicon, logos, og-image); not markdown, so no marker
+The distinction is by banner, not by folder. See
+[CONTENT_AGGREGATION.md](CONTENT_AGGREGATION.md) for the model, the pipeline, and the
+reasoning behind it.
 
-- **`managed: true`** — aggregated from an upstream repository. **Do not edit here.** The nightly aggregation run overwrites these files, so any local change is silently lost. The `github_repo` / `github_subdir` frontmatter fields point at the upstream source; open your PR there instead. A CI check (`enforce-managed-files`) blocks PRs that touch `managed: true` files.
+## ✏️ Making a change
 
-### How Content Gets Aggregated
+Route your change by **what** you are editing:
 
-Managed content is pulled from upstream repositories into `hugo/content/` by a
-scheduled CI job and committed to `master`. The structure of what gets
-aggregated is defined in the `.docforge/*.yaml` manifest files. Contributors do
-not run this aggregation locally; it happens in CI.
+| I want to change… | Where | Command | Made visible by |
+|---|---|---|---|
+| **Code / theme** (`.vitepress/**`, components, styles) | this repo | `make dev` | hot reload |
+| **Local content** (`LOCAL` file) | the file under `hugo/content/` | `make dev` | hot reload |
+| **Managed content** (`MANAGED` file) | the upstream repo it points to | open a PR **there** | the nightly aggregation run |
+| **Content structure** (add/remove/move a source) | `.docforge/*.yaml` | `make hugo-refresh` to preview locally | the aggregation run once the manifest change is merged |
 
-## ✏️ Contributing
+You may edit a `MANAGED` file locally to test a change, but the fix only counts once it is
+merged upstream — the nightly run overwrites any local edit, and CI blocks PRs that touch
+`MANAGED` files here.
 
-### Local Content
+### Creating a new local content file
 
-1. To modify local content, edit the `local: true` files directly in `hugo/content/`
-2. Content changes are reflected immediately when using `make dev`
+Any markdown file you add under `hugo/content/` **without** a `github_repo` frontmatter
+field is automatically `LOCAL`. There is nothing to register; placement in the tree
+determines the URL. Minimum frontmatter:
 
-### Blog Posts
+```yaml
+---
+title: Your Page Title
+---
+```
 
-1. Create new blog posts in `hugo/content/blog/YEAR/MONTH/your-post.md`
-2. Include front matter at the top of your file:
-   ```yaml
-   ---
-   local: true
-   title: Your Awesome Blog Post
-   description: "A brief description of your post"
-   date: 2025-06-24
-   authors:
-   - name: Your Name
-     email: your.email@example.com
-   ---
-   ```
+`title` is the only strictly required field. Optional layout fields: `description`,
+`editLink: false`, `prev: false` / `next: false`, `aside: false`, `sidebar: false`. Do
+**not** add `github_repo` or `auto_generated` — those flip the file to `MANAGED` or
+`GENERATED`.
 
-### Remote Content 
+### Adding a blog post
 
-Gardener documentation pulls content from multiple repositories. Key remote sources include:
+Create `hugo/content/blog/YEAR/MONTH/your-post.md`:
 
-- `gardener/gardener`: Core Gardener documentation
-- `gardener/dashboard`: Dashboard documentation
-- `gardener/gardenctl-v2`: CLI documentation
+```yaml
+---
+title: Your Awesome Blog Post
+description: "A brief description of your post"
+publishdate: '2025-06-24'
+authors:
+  - name: Your Name
+    login: your-github-handle
+    avatar: https://avatars.githubusercontent.com/u/<id>?v=4
+tags:
+  - community-event
+---
+```
 
-To modify these, submit changes to their respective repositories.
+## 🔧 Command reference
 
-## 🔧 Available Commands
+| Command | Purpose |
+|---|---|
+| `make dev` | Dev server with hot reload (code + local content) |
+| `make docker-preview` | Build and run the preview in Docker |
+| `make local-preview` | Production build, then local preview |
+| `make build` | Build the site into `dist/` |
+| `make post-process` | Run the full post-processing pipeline |
+| `make hugo-refresh` | **Manifest testing only:** delete managed banners, re-aggregate, post-process, stage |
+| `make vale` | Lint changed content markdown with Vale |
+| `make diff-structure-master` | Compare sitemap structure of working tree vs `origin/master` |
 
-### Documentation Development
+## 🤝 Contributing
 
-- `make dev` - Start the development server with live reloading
-- `make docker-preview` - Build and run the preview in a Docker container
-- `make local-preview` - Build and run the preview locally
-
+- For **local content**, edit the `LOCAL` files directly and open a PR here.
+- For **managed content**, open a PR in the upstream repository the file is aggregated
+  from (`gardener/gardener`, `gardener/dashboard`, `gardener/gardenctl-v2`, and others).
+- For **site/theme code**, open a PR here against `master`.

--- a/README.md
+++ b/README.md
@@ -68,9 +68,10 @@ merged upstream — the nightly run overwrites any local edit, and CI blocks PRs
 
 ### Creating a new local content file
 
-Any markdown file you add under `hugo/content/` **without** a `github_repo` frontmatter
-field is automatically `LOCAL`. There is nothing to register; placement in the tree
-determines the URL. Minimum frontmatter:
+Any markdown file you add under `hugo/content/` **without** a `github_repo` or
+`auto_generated` frontmatter field is automatically `LOCAL`. (`auto_generated: true`
+classifies a file as `GENERATED`, which is removed during cleanup.) There is nothing
+to register; placement in the tree determines the URL. Minimum frontmatter:
 
 ```yaml
 ---

--- a/delete-managed-banner.sh
+++ b/delete-managed-banner.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Deletes files recursively that contain the managed banner marker.
+# Deletes files recursively that carry a MANAGED or GENERATED banner marker.
+# Both marker kinds identify files the aggregation run recreates, so they are
+# safe to remove; LOCAL files are the source of truth and are left untouched.
 # When deleting a file leaves its directory without any .md files, the whole
 # directory is removed (including remaining assets), walking upwards so parent
 # directories that lose their last .md collapse as well.
@@ -35,12 +37,14 @@ fi
 # and cannot escape above the requested root.
 ROOT="$(cd "$TARGET" && pwd)"
 
-# The marker is unique enough on its own; matching the whole ASCII block
-# would be brittle across encodings.
-MARKER='<!-- BANNER:MANAGED -->'
+# Matches the MANAGED marker (aggregated upstream files) and the GENERATED
+# marker (navigation stubs written by post-processing/part-index.js). Both are
+# recreated by the aggregation run and safe to delete. LOCAL files are the
+# source of truth and must never match.
+MARKER_PATTERN='<!-- BANNER:MANAGED -->|<!-- BANNER:GENERATED -->'
 
 # Collect matches null-delimited to handle any filename safely.
-mapfile -d '' -t MATCHES < <(grep -rlZ --fixed-strings "$MARKER" "$ROOT" 2>/dev/null || true)
+mapfile -d '' -t MATCHES < <(grep -rlZE "$MARKER_PATTERN" "$ROOT" 2>/dev/null || true)
 
 COUNT=${#MATCHES[@]}
 

--- a/delete-managed-banner.sh
+++ b/delete-managed-banner.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Deletes files recursively that contain the managed banner marker.
+# When deleting a file leaves its directory without any .md files, the whole
+# directory is removed (including remaining assets), walking upwards so parent
+# directories that lose their last .md collapse as well.
+# Dry-run by default; pass --force to actually delete.
+
+usage() {
+  echo "Usage: $0 [--force] <path>" >&2
+  echo "  Without --force: only lists matching files and directories (dry-run)." >&2
+  exit 1
+}
+FORCE=0
+TARGET=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --force) FORCE=1; shift ;;
+    -h|--help) usage ;;
+    -*) echo "Unknown option: $1" >&2; usage ;;
+    *) TARGET="$1"; shift ;;
+  esac
+done
+
+[[ -z "$TARGET" ]] && usage
+
+if [[ ! -d "$TARGET" ]]; then
+  echo "Error: '$TARGET' is not a directory" >&2
+  exit 1
+fi
+
+# Normalize TARGET to an absolute path so the upward walk has a hard stop
+# and cannot escape above the requested root.
+ROOT="$(cd "$TARGET" && pwd)"
+
+# The marker is unique enough on its own; matching the whole ASCII block
+# would be brittle across encodings.
+MARKER='<!-- BANNER:MANAGED -->'
+
+# Collect matches null-delimited to handle any filename safely.
+mapfile -d '' -t MATCHES < <(grep -rlZ --fixed-strings "$MARKER" "$ROOT" 2>/dev/null || true)
+
+COUNT=${#MATCHES[@]}
+
+if [[ $COUNT -eq 0 ]]; then
+  echo "No files contain the marker under '$ROOT'."
+  exit 0
+fi
+
+# True when the directory contains no .md files at any depth below it.
+dir_has_no_md() {
+  local dir="$1"
+  [[ -z "$(find "$dir" -type f -name '*.md' -print -quit)" ]]
+}
+
+# If a directory has lost all its .md files, remove it entirely (including any
+# leftover assets) and repeat for the parent, stopping at ROOT (exclusive).
+prune_md_less_dirs() {
+  local dir="$1"
+  while [[ "$dir" != "$ROOT" && "$dir" == "$ROOT"/* ]]; do
+    [[ -d "$dir" ]] || break
+    dir_has_no_md "$dir" || break
+    rm -rf -- "$dir"
+    echo "removed dir (no .md left): $dir"
+    dir="$(dirname "$dir")"
+  done
+}
+
+if [[ $FORCE -eq 1 ]]; then
+  for f in "${MATCHES[@]}"; do
+    # A parent may already be gone if a sibling deletion pruned it.
+    [[ -e "$f" ]] || continue
+    rm -- "$f"
+    echo "deleted: $f"
+    prune_md_less_dirs "$(dirname "$f")"
+  done
+  echo "Deleted $COUNT file(s)."
+else
+  echo "Dry-run: $COUNT file(s) would be deleted (pass --force to delete):"
+  for f in "${MATCHES[@]}"; do
+    echo "  $f"
+  done
+fi

--- a/delete-managed-banner.sh
+++ b/delete-managed-banner.sh
@@ -41,10 +41,30 @@ ROOT="$(cd "$TARGET" && pwd)"
 # marker (navigation stubs written by post-processing/part-index.js). Both are
 # recreated by the aggregation run and safe to delete. LOCAL files are the
 # source of truth and must never match.
+#
+# grep only prefilters candidates that mention the marker text anywhere; a bare
+# grep -l would also match marker strings buried in prose or fenced code blocks.
+# select-banner-files.mjs then parses each candidate's frontmatter and keeps it
+# only when splitLeadingBanner finds a MANAGED/GENERATED banner as the first
+# thing after the frontmatter, mirroring post-processing/part-1.js.
 MARKER_PATTERN='<!-- BANNER:MANAGED -->|<!-- BANNER:GENERATED -->'
 
-# Collect matches null-delimited to handle any filename safely.
-mapfile -d '' -t MATCHES < <(grep -rlZE "$MARKER_PATTERN" "$ROOT" 2>/dev/null || true)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NODE_BIN="$(command -v node || true)"
+if [[ -z "$NODE_BIN" ]]; then
+  echo "Error: node is required to validate leading banners" >&2
+  exit 1
+fi
+
+# grep prefilters candidates that mention the marker text anywhere, then
+# select-banner-files.mjs validates each one. The helper accepts NUL- or
+# newline-delimited input (GNU grep -Z uses NUL; BSD/macOS grep -l uses
+# newlines) and always emits NUL-delimited paths, so mapfile -d '' reads them
+# safely regardless of filename contents.
+mapfile -d '' -t MATCHES < <(
+  grep -rlZE "$MARKER_PATTERN" "$ROOT" 2>/dev/null |
+    "$NODE_BIN" "$SCRIPT_DIR/post-processing/select-banner-files.mjs"
+)
 
 COUNT=${#MATCHES[@]}
 

--- a/hugo/content/community/hackathons/2026-11.md
+++ b/hugo/content/community/hackathons/2026-11.md
@@ -1,37 +1,23 @@
 ---
-github_repo: 'https://github.com/gardener/documentation'
-github_subdir: hugo/content/community/hackathons
 outline: 2
-params:
-  github_branch: master
-path_base_for_github_subdir:
-  from: content/community/hackathons/2026-11.md
-  to: 2026-11.md
 title: November 2026
-weight: -202611
+weight: -202605
 prev: false
 next: false
-local: true
 ---
-<!-- BANNER:MANAGED -->
+<!-- BANNER:LOCAL -->
 <!--
-   █▀▀ ▀█▀ █▀█ █▀█
-   ▀▀█  █  █ █ █▀▀
-   ▀▀▀  ▀  ▀▀▀ ▀
+   █▀█ █▄▀
+   █ █ █▀▄
+   ▀▀▀ ▀ ▀
 
    ┌────────────────────────────────────────────────┐
-   │  MANAGED FILE — aggregated from upstream       │
-   │                                                │
-   │  Editing here is pointless: The nightly        │
-   │  aggregation run overwrites this file.         │
-   │                                                │
-   │  Open a PR against the source instead: ─────┐  │
-   │                          ┌──┐    ┌──────────┘  │
-   │                          └──│────┘             │
-   │           ┌─────────────────┘                  │
-   └───────────│────────────────────────────────────┘
-               ▼               
-   https://github.com/gardener/documentation/blob/master/hugo/content/community/hackathons/2026-11.md
+   │  LOCAL FILE — maintained in gardener/            │
+   │  documentation.                                  │
+   │                                                  │
+   │  Go ahead and edit this file directly.           │
+   │  Changes here are the source of truth.           │
+   └────────────────────────────────────────────────┘
 -->
 
 

--- a/hugo/content/contribute/dashboard/index.md
+++ b/hugo/content/contribute/dashboard/index.md
@@ -11,7 +11,6 @@ title: Dashboard
 weight: 60
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/contribute/extensions/gardener-extension-auditing/index.md
+++ b/hugo/content/contribute/extensions/gardener-extension-auditing/index.md
@@ -10,7 +10,6 @@ path_base_for_github_subdir:
 title: Kubernetes Auditing
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/contribute/extensions/gardener-extension-registry-cache/index.md
+++ b/hugo/content/contribute/extensions/gardener-extension-registry-cache/index.md
@@ -10,7 +10,6 @@ path_base_for_github_subdir:
 title: Registry Cache
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/contribute/extensions/gardener-extension-shoot-dns-service/index.md
+++ b/hugo/content/contribute/extensions/gardener-extension-shoot-dns-service/index.md
@@ -10,7 +10,6 @@ path_base_for_github_subdir:
 title: DNS Services
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/contribute/extensions/gardener-extension-shoot-rsyslog-relp/index.md
+++ b/hugo/content/contribute/extensions/gardener-extension-shoot-rsyslog-relp/index.md
@@ -11,7 +11,6 @@ path_base_for_github_subdir:
 title: Node Audit Logging
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/contribute/extensions/gardener-extension-shoot-traefik/index.md
+++ b/hugo/content/contribute/extensions/gardener-extension-shoot-traefik/index.md
@@ -10,7 +10,6 @@ path_base_for_github_subdir:
 title: Traefik Ingress
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/contribute/extensions/infrastructure-extensions/gardener-extension-provider-alicloud/index.md
+++ b/hugo/content/contribute/extensions/infrastructure-extensions/gardener-extension-provider-alicloud/index.md
@@ -11,7 +11,6 @@ path_base_for_github_subdir:
 title: Provider Alibaba Cloud
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/contribute/extensions/infrastructure-extensions/gardener-extension-provider-aws/index.md
+++ b/hugo/content/contribute/extensions/infrastructure-extensions/gardener-extension-provider-aws/index.md
@@ -11,7 +11,6 @@ path_base_for_github_subdir:
 title: Provider AWS
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/contribute/extensions/infrastructure-extensions/gardener-extension-provider-azure/index.md
+++ b/hugo/content/contribute/extensions/infrastructure-extensions/gardener-extension-provider-azure/index.md
@@ -11,7 +11,6 @@ path_base_for_github_subdir:
 title: Provider Azure
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/contribute/extensions/infrastructure-extensions/gardener-extension-provider-gcp/index.md
+++ b/hugo/content/contribute/extensions/infrastructure-extensions/gardener-extension-provider-gcp/index.md
@@ -11,7 +11,6 @@ path_base_for_github_subdir:
 title: Provider GCP
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/contribute/extensions/infrastructure-extensions/gardener-extension-provider-ironcore-metal/index.md
+++ b/hugo/content/contribute/extensions/infrastructure-extensions/gardener-extension-provider-ironcore-metal/index.md
@@ -11,7 +11,6 @@ path_base_for_github_subdir:
 title: Provider IronCore Metal
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/contribute/extensions/infrastructure-extensions/gardener-extension-provider-ironcore/index.md
+++ b/hugo/content/contribute/extensions/infrastructure-extensions/gardener-extension-provider-ironcore/index.md
@@ -11,7 +11,6 @@ path_base_for_github_subdir:
 title: Provider IronCore
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/contribute/extensions/infrastructure-extensions/gardener-extension-provider-openstack/index.md
+++ b/hugo/content/contribute/extensions/infrastructure-extensions/gardener-extension-provider-openstack/index.md
@@ -11,7 +11,6 @@ path_base_for_github_subdir:
 title: Provider OpenStack
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/contribute/other-components/dependency-watchdog/index.md
+++ b/hugo/content/contribute/other-components/dependency-watchdog/index.md
@@ -10,7 +10,6 @@ path_base_for_github_subdir:
 title: Dependency Watchdog
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/contribute/other-components/etcd-druid/index.md
+++ b/hugo/content/contribute/other-components/etcd-druid/index.md
@@ -10,7 +10,6 @@ path_base_for_github_subdir:
 title: etcd-druid
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/contribute/other-components/machine-controller-manager/index.md
+++ b/hugo/content/contribute/other-components/machine-controller-manager/index.md
@@ -10,7 +10,6 @@ path_base_for_github_subdir:
 title: Machine Controller Manager
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/dashboard/index.md
+++ b/hugo/content/docs/dashboard/index.md
@@ -11,7 +11,6 @@ title: Dashboard
 weight: 60
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/extensions/container-runtime-extensions/gardener-extension-runtime-gvisor/index.md
+++ b/hugo/content/docs/extensions/container-runtime-extensions/gardener-extension-runtime-gvisor/index.md
@@ -11,7 +11,6 @@ path_base_for_github_subdir:
 title: GVisor container runtime
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/extensions/index.md
+++ b/hugo/content/docs/extensions/index.md
@@ -11,7 +11,6 @@ title: List of Extensions
 weight: 40
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/extensions/infrastructure-extensions/gardener-extension-provider-alicloud/index.md
+++ b/hugo/content/docs/extensions/infrastructure-extensions/gardener-extension-provider-alicloud/index.md
@@ -11,7 +11,6 @@ path_base_for_github_subdir:
 title: Provider Alibaba Cloud
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/extensions/infrastructure-extensions/gardener-extension-provider-aws/index.md
+++ b/hugo/content/docs/extensions/infrastructure-extensions/gardener-extension-provider-aws/index.md
@@ -11,7 +11,6 @@ path_base_for_github_subdir:
 title: Provider AWS
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/extensions/infrastructure-extensions/gardener-extension-provider-azure/index.md
+++ b/hugo/content/docs/extensions/infrastructure-extensions/gardener-extension-provider-azure/index.md
@@ -11,7 +11,6 @@ path_base_for_github_subdir:
 title: Provider Azure
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/extensions/infrastructure-extensions/gardener-extension-provider-gcp/index.md
+++ b/hugo/content/docs/extensions/infrastructure-extensions/gardener-extension-provider-gcp/index.md
@@ -11,7 +11,6 @@ path_base_for_github_subdir:
 title: Provider GCP
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/extensions/infrastructure-extensions/gardener-extension-provider-ironcore-metal/index.md
+++ b/hugo/content/docs/extensions/infrastructure-extensions/gardener-extension-provider-ironcore-metal/index.md
@@ -11,7 +11,6 @@ path_base_for_github_subdir:
 title: Provider IronCore Metal
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/extensions/infrastructure-extensions/gardener-extension-provider-ironcore/index.md
+++ b/hugo/content/docs/extensions/infrastructure-extensions/gardener-extension-provider-ironcore/index.md
@@ -11,7 +11,6 @@ path_base_for_github_subdir:
 title: Provider IronCore
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/extensions/infrastructure-extensions/gardener-extension-provider-metal/index.md
+++ b/hugo/content/docs/extensions/infrastructure-extensions/gardener-extension-provider-metal/index.md
@@ -11,7 +11,6 @@ path_base_for_github_subdir:
 title: Provider metal-stack
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/extensions/infrastructure-extensions/gardener-extension-provider-openstack/index.md
+++ b/hugo/content/docs/extensions/infrastructure-extensions/gardener-extension-provider-openstack/index.md
@@ -11,7 +11,6 @@ path_base_for_github_subdir:
 title: Provider OpenStack
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/extensions/infrastructure-extensions/gardener-extension-provider-stackit/index.md
+++ b/hugo/content/docs/extensions/infrastructure-extensions/gardener-extension-provider-stackit/index.md
@@ -11,7 +11,6 @@ path_base_for_github_subdir:
 title: Provider STACKIT
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/extensions/network-extensions/gardener-extension-networking-calico/index.md
+++ b/hugo/content/docs/extensions/network-extensions/gardener-extension-networking-calico/index.md
@@ -11,7 +11,6 @@ path_base_for_github_subdir:
 title: Calico CNI
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/extensions/network-extensions/gardener-extension-networking-cilium/index.md
+++ b/hugo/content/docs/extensions/network-extensions/gardener-extension-networking-cilium/index.md
@@ -11,7 +11,6 @@ path_base_for_github_subdir:
 title: Cilium CNI
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/extensions/os-extensions/gardener-extension-os-coreos/index.md
+++ b/hugo/content/docs/extensions/os-extensions/gardener-extension-os-coreos/index.md
@@ -12,7 +12,6 @@ path_base_for_github_subdir:
 title: CoreOS/FlatCar OS
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/extensions/os-extensions/gardener-extension-os-gardenlinux/index.md
+++ b/hugo/content/docs/extensions/os-extensions/gardener-extension-os-gardenlinux/index.md
@@ -11,7 +11,6 @@ path_base_for_github_subdir:
 title: Garden Linux OS
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/extensions/os-extensions/gardener-extension-os-suse-chost/index.md
+++ b/hugo/content/docs/extensions/os-extensions/gardener-extension-os-suse-chost/index.md
@@ -13,7 +13,6 @@ path_base_for_github_subdir:
 title: SUSE CHost OS
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/extensions/os-extensions/gardener-extension-os-ubuntu/index.md
+++ b/hugo/content/docs/extensions/os-extensions/gardener-extension-os-ubuntu/index.md
@@ -10,7 +10,6 @@ path_base_for_github_subdir:
 title: Ubuntu OS
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/extensions/others/gardener-extension-auditing/api-reference/index.md
+++ b/hugo/content/docs/extensions/others/gardener-extension-auditing/api-reference/index.md
@@ -10,7 +10,6 @@ path_base_for_github_subdir:
 title: Api Reference
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/extensions/others/gardener-extension-auditing/index.md
+++ b/hugo/content/docs/extensions/others/gardener-extension-auditing/index.md
@@ -12,7 +12,6 @@ path_base_for_github_subdir:
 title: Kubernetes Auditing
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/extensions/others/gardener-extension-registry-cache/index.md
+++ b/hugo/content/docs/extensions/others/gardener-extension-registry-cache/index.md
@@ -12,7 +12,6 @@ path_base_for_github_subdir:
 title: Registry Cache
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/extensions/others/gardener-extension-registry-cache/registry-cache/index.md
+++ b/hugo/content/docs/extensions/others/gardener-extension-registry-cache/registry-cache/index.md
@@ -1,9 +1,26 @@
 ---
-title: "Registry cache"
+title: Registry cache
 auto_generated: true
 generated_by: post-processing/part-3.js addMissingIndexFiles function
 prev: false
 next: false
 editLink: false
 ---
+<!-- BANNER:GENERATED -->
+<!--
+   █▀▀ █▀▀ █▄ █
+   █ █ █▀▀ █ ▀█
+   ▀▀▀ ▀▀▀ ▀  ▀
+
+   ┌────────────────────────────────────────────────┐
+   │  GENERATED FILE — navigation stub              │
+   │                                                │
+   │  Created by post-processing/part-index.js      │
+   │  (addMissingIndexFiles). It has no upstream     │
+   │  source; the aggregation run recreates it.      │
+   │                                                │
+   │  Do not edit and do not commit by hand.         │
+   └────────────────────────────────────────────────┘
+-->
+
 

--- a/hugo/content/docs/extensions/others/gardener-extension-registry-cache/registry-cache/index.md
+++ b/hugo/content/docs/extensions/others/gardener-extension-registry-cache/registry-cache/index.md
@@ -1,7 +1,7 @@
 ---
 title: Registry cache
 auto_generated: true
-generated_by: post-processing/part-3.js addMissingIndexFiles function
+generated_by: post-processing/part-index.js addMissingIndexFiles function
 prev: false
 next: false
 editLink: false

--- a/hugo/content/docs/extensions/others/gardener-extension-registry-cache/registry-cache/index.md
+++ b/hugo/content/docs/extensions/others/gardener-extension-registry-cache/registry-cache/index.md
@@ -16,10 +16,10 @@ editLink: false
    │  GENERATED FILE — navigation stub              │
    │                                                │
    │  Created by post-processing/part-index.js      │
-   │  (addMissingIndexFiles). It has no upstream     │
-   │  source; the aggregation run recreates it.      │
+   │  (addMissingIndexFiles). It has no upstream    │
+   │  source; the aggregation run recreates it.     │
    │                                                │
-   │  Do not edit and do not commit by hand.         │
+   │  Do not edit and do not commit by hand.        │
    └────────────────────────────────────────────────┘
 -->
 

--- a/hugo/content/docs/extensions/others/gardener-extension-registry-cache/registry-mirror/index.md
+++ b/hugo/content/docs/extensions/others/gardener-extension-registry-cache/registry-mirror/index.md
@@ -1,7 +1,7 @@
 ---
 title: Registry mirror
 auto_generated: true
-generated_by: post-processing/part-3.js addMissingIndexFiles function
+generated_by: post-processing/part-index.js addMissingIndexFiles function
 prev: false
 next: false
 editLink: false

--- a/hugo/content/docs/extensions/others/gardener-extension-registry-cache/registry-mirror/index.md
+++ b/hugo/content/docs/extensions/others/gardener-extension-registry-cache/registry-mirror/index.md
@@ -1,9 +1,26 @@
 ---
-title: "Registry mirror"
+title: Registry mirror
 auto_generated: true
 generated_by: post-processing/part-3.js addMissingIndexFiles function
 prev: false
 next: false
 editLink: false
 ---
+<!-- BANNER:GENERATED -->
+<!--
+   █▀▀ █▀▀ █▄ █
+   █ █ █▀▀ █ ▀█
+   ▀▀▀ ▀▀▀ ▀  ▀
+
+   ┌────────────────────────────────────────────────┐
+   │  GENERATED FILE — navigation stub              │
+   │                                                │
+   │  Created by post-processing/part-index.js      │
+   │  (addMissingIndexFiles). It has no upstream     │
+   │  source; the aggregation run recreates it.      │
+   │                                                │
+   │  Do not edit and do not commit by hand.         │
+   └────────────────────────────────────────────────┘
+-->
+
 

--- a/hugo/content/docs/extensions/others/gardener-extension-registry-cache/registry-mirror/index.md
+++ b/hugo/content/docs/extensions/others/gardener-extension-registry-cache/registry-mirror/index.md
@@ -16,10 +16,10 @@ editLink: false
    │  GENERATED FILE — navigation stub              │
    │                                                │
    │  Created by post-processing/part-index.js      │
-   │  (addMissingIndexFiles). It has no upstream     │
-   │  source; the aggregation run recreates it.      │
+   │  (addMissingIndexFiles). It has no upstream    │
+   │  source; the aggregation run recreates it.     │
    │                                                │
-   │  Do not edit and do not commit by hand.         │
+   │  Do not edit and do not commit by hand.        │
    └────────────────────────────────────────────────┘
 -->
 

--- a/hugo/content/docs/extensions/others/gardener-extension-shoot-cert-service/index.md
+++ b/hugo/content/docs/extensions/others/gardener-extension-shoot-cert-service/index.md
@@ -11,7 +11,6 @@ path_base_for_github_subdir:
 title: Certificate Services
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/extensions/others/gardener-extension-shoot-cert-service/tutorials/index.md
+++ b/hugo/content/docs/extensions/others/gardener-extension-shoot-cert-service/tutorials/index.md
@@ -1,7 +1,7 @@
 ---
 title: Tutorials
 auto_generated: true
-generated_by: post-processing/part-3.js addMissingIndexFiles function
+generated_by: post-processing/part-index.js addMissingIndexFiles function
 prev: false
 next: false
 editLink: false

--- a/hugo/content/docs/extensions/others/gardener-extension-shoot-cert-service/tutorials/index.md
+++ b/hugo/content/docs/extensions/others/gardener-extension-shoot-cert-service/tutorials/index.md
@@ -1,9 +1,26 @@
 ---
-title: "Tutorials"
+title: Tutorials
 auto_generated: true
 generated_by: post-processing/part-3.js addMissingIndexFiles function
 prev: false
 next: false
 editLink: false
 ---
+<!-- BANNER:GENERATED -->
+<!--
+   █▀▀ █▀▀ █▄ █
+   █ █ █▀▀ █ ▀█
+   ▀▀▀ ▀▀▀ ▀  ▀
+
+   ┌────────────────────────────────────────────────┐
+   │  GENERATED FILE — navigation stub              │
+   │                                                │
+   │  Created by post-processing/part-index.js      │
+   │  (addMissingIndexFiles). It has no upstream     │
+   │  source; the aggregation run recreates it.      │
+   │                                                │
+   │  Do not edit and do not commit by hand.         │
+   └────────────────────────────────────────────────┘
+-->
+
 

--- a/hugo/content/docs/extensions/others/gardener-extension-shoot-cert-service/tutorials/index.md
+++ b/hugo/content/docs/extensions/others/gardener-extension-shoot-cert-service/tutorials/index.md
@@ -16,10 +16,10 @@ editLink: false
    │  GENERATED FILE — navigation stub              │
    │                                                │
    │  Created by post-processing/part-index.js      │
-   │  (addMissingIndexFiles). It has no upstream     │
-   │  source; the aggregation run recreates it.      │
+   │  (addMissingIndexFiles). It has no upstream    │
+   │  source; the aggregation run recreates it.     │
    │                                                │
-   │  Do not edit and do not commit by hand.         │
+   │  Do not edit and do not commit by hand.        │
    └────────────────────────────────────────────────┘
 -->
 

--- a/hugo/content/docs/extensions/others/gardener-extension-shoot-dns-service/index.md
+++ b/hugo/content/docs/extensions/others/gardener-extension-shoot-dns-service/index.md
@@ -11,7 +11,6 @@ path_base_for_github_subdir:
 title: DNS Services
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/extensions/others/gardener-extension-shoot-dns-service/tutorials/index.md
+++ b/hugo/content/docs/extensions/others/gardener-extension-shoot-dns-service/tutorials/index.md
@@ -1,7 +1,7 @@
 ---
 title: Tutorials
 auto_generated: true
-generated_by: post-processing/part-3.js addMissingIndexFiles function
+generated_by: post-processing/part-index.js addMissingIndexFiles function
 prev: false
 next: false
 editLink: false

--- a/hugo/content/docs/extensions/others/gardener-extension-shoot-dns-service/tutorials/index.md
+++ b/hugo/content/docs/extensions/others/gardener-extension-shoot-dns-service/tutorials/index.md
@@ -1,9 +1,26 @@
 ---
-title: "Tutorials"
+title: Tutorials
 auto_generated: true
 generated_by: post-processing/part-3.js addMissingIndexFiles function
 prev: false
 next: false
 editLink: false
 ---
+<!-- BANNER:GENERATED -->
+<!--
+   █▀▀ █▀▀ █▄ █
+   █ █ █▀▀ █ ▀█
+   ▀▀▀ ▀▀▀ ▀  ▀
+
+   ┌────────────────────────────────────────────────┐
+   │  GENERATED FILE — navigation stub              │
+   │                                                │
+   │  Created by post-processing/part-index.js      │
+   │  (addMissingIndexFiles). It has no upstream     │
+   │  source; the aggregation run recreates it.      │
+   │                                                │
+   │  Do not edit and do not commit by hand.         │
+   └────────────────────────────────────────────────┘
+-->
+
 

--- a/hugo/content/docs/extensions/others/gardener-extension-shoot-dns-service/tutorials/index.md
+++ b/hugo/content/docs/extensions/others/gardener-extension-shoot-dns-service/tutorials/index.md
@@ -16,10 +16,10 @@ editLink: false
    │  GENERATED FILE — navigation stub              │
    │                                                │
    │  Created by post-processing/part-index.js      │
-   │  (addMissingIndexFiles). It has no upstream     │
-   │  source; the aggregation run recreates it.      │
+   │  (addMissingIndexFiles). It has no upstream    │
+   │  source; the aggregation run recreates it.     │
    │                                                │
-   │  Do not edit and do not commit by hand.         │
+   │  Do not edit and do not commit by hand.        │
    └────────────────────────────────────────────────┘
 -->
 

--- a/hugo/content/docs/extensions/others/gardener-extension-shoot-dns-service/workloadidentity/index.md
+++ b/hugo/content/docs/extensions/others/gardener-extension-shoot-dns-service/workloadidentity/index.md
@@ -1,7 +1,7 @@
 ---
 title: Workloadidentity
 auto_generated: true
-generated_by: post-processing/part-3.js addMissingIndexFiles function
+generated_by: post-processing/part-index.js addMissingIndexFiles function
 prev: false
 next: false
 editLink: false

--- a/hugo/content/docs/extensions/others/gardener-extension-shoot-dns-service/workloadidentity/index.md
+++ b/hugo/content/docs/extensions/others/gardener-extension-shoot-dns-service/workloadidentity/index.md
@@ -1,9 +1,26 @@
 ---
-title: "Workloadidentity"
+title: Workloadidentity
 auto_generated: true
 generated_by: post-processing/part-3.js addMissingIndexFiles function
 prev: false
 next: false
 editLink: false
 ---
+<!-- BANNER:GENERATED -->
+<!--
+   █▀▀ █▀▀ █▄ █
+   █ █ █▀▀ █ ▀█
+   ▀▀▀ ▀▀▀ ▀  ▀
+
+   ┌────────────────────────────────────────────────┐
+   │  GENERATED FILE — navigation stub              │
+   │                                                │
+   │  Created by post-processing/part-index.js      │
+   │  (addMissingIndexFiles). It has no upstream     │
+   │  source; the aggregation run recreates it.      │
+   │                                                │
+   │  Do not edit and do not commit by hand.         │
+   └────────────────────────────────────────────────┘
+-->
+
 

--- a/hugo/content/docs/extensions/others/gardener-extension-shoot-dns-service/workloadidentity/index.md
+++ b/hugo/content/docs/extensions/others/gardener-extension-shoot-dns-service/workloadidentity/index.md
@@ -16,10 +16,10 @@ editLink: false
    │  GENERATED FILE — navigation stub              │
    │                                                │
    │  Created by post-processing/part-index.js      │
-   │  (addMissingIndexFiles). It has no upstream     │
-   │  source; the aggregation run recreates it.      │
+   │  (addMissingIndexFiles). It has no upstream    │
+   │  source; the aggregation run recreates it.     │
    │                                                │
-   │  Do not edit and do not commit by hand.         │
+   │  Do not edit and do not commit by hand.        │
    └────────────────────────────────────────────────┘
 -->
 

--- a/hugo/content/docs/extensions/others/gardener-extension-shoot-lakom-service/index.md
+++ b/hugo/content/docs/extensions/others/gardener-extension-shoot-lakom-service/index.md
@@ -13,7 +13,6 @@ path_base_for_github_subdir:
 title: Lakom Service
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/extensions/others/gardener-extension-shoot-networking-filter/index.md
+++ b/hugo/content/docs/extensions/others/gardener-extension-shoot-networking-filter/index.md
@@ -11,7 +11,6 @@ path_base_for_github_subdir:
 title: Egress Filtering
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/extensions/others/gardener-extension-shoot-networking-problemdetector/index.md
+++ b/hugo/content/docs/extensions/others/gardener-extension-shoot-networking-problemdetector/index.md
@@ -12,7 +12,6 @@ path_base_for_github_subdir:
 title: Networking Problem Detector
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/extensions/others/gardener-extension-shoot-oidc-service/index.md
+++ b/hugo/content/docs/extensions/others/gardener-extension-shoot-oidc-service/index.md
@@ -11,7 +11,6 @@ path_base_for_github_subdir:
 title: OpenID Connect Services
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/extensions/others/gardener-extension-shoot-rsyslog-relp/index.md
+++ b/hugo/content/docs/extensions/others/gardener-extension-shoot-rsyslog-relp/index.md
@@ -13,7 +13,6 @@ path_base_for_github_subdir:
 title: Node Audit Logging
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/extensions/others/gardener-extension-shoot-traefik/index.md
+++ b/hugo/content/docs/extensions/others/gardener-extension-shoot-traefik/index.md
@@ -12,7 +12,6 @@ path_base_for_github_subdir:
 title: Traefik Ingress
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/gardenctl-v2/index.md
+++ b/hugo/content/docs/gardenctl-v2/index.md
@@ -13,7 +13,6 @@ title: Gardenctl
 weight: 70
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/gardener/api-reference/index.md
+++ b/hugo/content/docs/gardener/api-reference/index.md
@@ -12,7 +12,6 @@ title: API Reference
 weight: 10
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/gardener/extensions/index.md
+++ b/hugo/content/docs/gardener/extensions/index.md
@@ -10,7 +10,6 @@ title: Extensions
 weight: 30
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/gardener/index.md
+++ b/hugo/content/docs/gardener/index.md
@@ -13,7 +13,6 @@ title: Gardener
 weight: 30
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/gardener/monitoring/index.md
+++ b/hugo/content/docs/gardener/monitoring/index.md
@@ -11,7 +11,6 @@ title: Monitoring
 weight: 50
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/other-components/dependency-watchdog/concepts/index.md
+++ b/hugo/content/docs/other-components/dependency-watchdog/concepts/index.md
@@ -11,7 +11,6 @@ title: Concepts
 weight: 2
 prev: false
 next: false
-managed: true
 editLink: false
 ---
 <!-- BANNER:MANAGED -->

--- a/hugo/content/docs/other-components/dependency-watchdog/deployment/index.md
+++ b/hugo/content/docs/other-components/dependency-watchdog/deployment/index.md
@@ -11,7 +11,6 @@ title: Deployment
 weight: 3
 prev: false
 next: false
-managed: true
 editLink: false
 ---
 <!-- BANNER:MANAGED -->

--- a/hugo/content/docs/other-components/dependency-watchdog/index.md
+++ b/hugo/content/docs/other-components/dependency-watchdog/index.md
@@ -12,7 +12,6 @@ path_base_for_github_subdir:
 title: Dependency Watchdog
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/other-components/etcd-druid/concepts/index.md
+++ b/hugo/content/docs/other-components/etcd-druid/concepts/index.md
@@ -1,9 +1,26 @@
 ---
-title: "Concepts"
+title: Concepts
 auto_generated: true
 generated_by: post-processing/part-3.js addMissingIndexFiles function
 prev: false
 next: false
 editLink: false
 ---
+<!-- BANNER:GENERATED -->
+<!--
+   █▀▀ █▀▀ █▄ █
+   █ █ █▀▀ █ ▀█
+   ▀▀▀ ▀▀▀ ▀  ▀
+
+   ┌────────────────────────────────────────────────┐
+   │  GENERATED FILE — navigation stub              │
+   │                                                │
+   │  Created by post-processing/part-index.js      │
+   │  (addMissingIndexFiles). It has no upstream     │
+   │  source; the aggregation run recreates it.      │
+   │                                                │
+   │  Do not edit and do not commit by hand.         │
+   └────────────────────────────────────────────────┘
+-->
+
 

--- a/hugo/content/docs/other-components/etcd-druid/concepts/index.md
+++ b/hugo/content/docs/other-components/etcd-druid/concepts/index.md
@@ -1,7 +1,7 @@
 ---
 title: Concepts
 auto_generated: true
-generated_by: post-processing/part-3.js addMissingIndexFiles function
+generated_by: post-processing/part-index.js addMissingIndexFiles function
 prev: false
 next: false
 editLink: false

--- a/hugo/content/docs/other-components/etcd-druid/concepts/index.md
+++ b/hugo/content/docs/other-components/etcd-druid/concepts/index.md
@@ -16,10 +16,10 @@ editLink: false
    │  GENERATED FILE — navigation stub              │
    │                                                │
    │  Created by post-processing/part-index.js      │
-   │  (addMissingIndexFiles). It has no upstream     │
-   │  source; the aggregation run recreates it.      │
+   │  (addMissingIndexFiles). It has no upstream    │
+   │  source; the aggregation run recreates it.     │
    │                                                │
-   │  Do not edit and do not commit by hand.         │
+   │  Do not edit and do not commit by hand.        │
    └────────────────────────────────────────────────┘
 -->
 

--- a/hugo/content/docs/other-components/etcd-druid/deployment/getting-started-locally/index.md
+++ b/hugo/content/docs/other-components/etcd-druid/deployment/getting-started-locally/index.md
@@ -1,9 +1,26 @@
 ---
-title: "Getting started locally"
+title: Getting started locally
 auto_generated: true
 generated_by: post-processing/part-3.js addMissingIndexFiles function
 prev: false
 next: false
 editLink: false
 ---
+<!-- BANNER:GENERATED -->
+<!--
+   █▀▀ █▀▀ █▄ █
+   █ █ █▀▀ █ ▀█
+   ▀▀▀ ▀▀▀ ▀  ▀
+
+   ┌────────────────────────────────────────────────┐
+   │  GENERATED FILE — navigation stub              │
+   │                                                │
+   │  Created by post-processing/part-index.js      │
+   │  (addMissingIndexFiles). It has no upstream     │
+   │  source; the aggregation run recreates it.      │
+   │                                                │
+   │  Do not edit and do not commit by hand.         │
+   └────────────────────────────────────────────────┘
+-->
+
 

--- a/hugo/content/docs/other-components/etcd-druid/deployment/getting-started-locally/index.md
+++ b/hugo/content/docs/other-components/etcd-druid/deployment/getting-started-locally/index.md
@@ -1,7 +1,7 @@
 ---
 title: Getting started locally
 auto_generated: true
-generated_by: post-processing/part-3.js addMissingIndexFiles function
+generated_by: post-processing/part-index.js addMissingIndexFiles function
 prev: false
 next: false
 editLink: false

--- a/hugo/content/docs/other-components/etcd-druid/deployment/getting-started-locally/index.md
+++ b/hugo/content/docs/other-components/etcd-druid/deployment/getting-started-locally/index.md
@@ -16,10 +16,10 @@ editLink: false
    │  GENERATED FILE — navigation stub              │
    │                                                │
    │  Created by post-processing/part-index.js      │
-   │  (addMissingIndexFiles). It has no upstream     │
-   │  source; the aggregation run recreates it.      │
+   │  (addMissingIndexFiles). It has no upstream    │
+   │  source; the aggregation run recreates it.     │
    │                                                │
-   │  Do not edit and do not commit by hand.         │
+   │  Do not edit and do not commit by hand.        │
    └────────────────────────────────────────────────┘
 -->
 

--- a/hugo/content/docs/other-components/etcd-druid/deployment/index.md
+++ b/hugo/content/docs/other-components/etcd-druid/deployment/index.md
@@ -1,7 +1,7 @@
 ---
 title: Deployment
 auto_generated: true
-generated_by: post-processing/part-3.js addMissingIndexFiles function
+generated_by: post-processing/part-index.js addMissingIndexFiles function
 prev: false
 next: false
 editLink: false

--- a/hugo/content/docs/other-components/etcd-druid/deployment/index.md
+++ b/hugo/content/docs/other-components/etcd-druid/deployment/index.md
@@ -1,9 +1,26 @@
 ---
-title: "Deployment"
+title: Deployment
 auto_generated: true
 generated_by: post-processing/part-3.js addMissingIndexFiles function
 prev: false
 next: false
 editLink: false
 ---
+<!-- BANNER:GENERATED -->
+<!--
+   █▀▀ █▀▀ █▄ █
+   █ █ █▀▀ █ ▀█
+   ▀▀▀ ▀▀▀ ▀  ▀
+
+   ┌────────────────────────────────────────────────┐
+   │  GENERATED FILE — navigation stub              │
+   │                                                │
+   │  Created by post-processing/part-index.js      │
+   │  (addMissingIndexFiles). It has no upstream     │
+   │  source; the aggregation run recreates it.      │
+   │                                                │
+   │  Do not edit and do not commit by hand.         │
+   └────────────────────────────────────────────────┘
+-->
+
 

--- a/hugo/content/docs/other-components/etcd-druid/deployment/index.md
+++ b/hugo/content/docs/other-components/etcd-druid/deployment/index.md
@@ -16,10 +16,10 @@ editLink: false
    │  GENERATED FILE — navigation stub              │
    │                                                │
    │  Created by post-processing/part-index.js      │
-   │  (addMissingIndexFiles). It has no upstream     │
-   │  source; the aggregation run recreates it.      │
+   │  (addMissingIndexFiles). It has no upstream    │
+   │  source; the aggregation run recreates it.     │
    │                                                │
-   │  Do not edit and do not commit by hand.         │
+   │  Do not edit and do not commit by hand.        │
    └────────────────────────────────────────────────┘
 -->
 

--- a/hugo/content/docs/other-components/etcd-druid/proposals/index.md
+++ b/hugo/content/docs/other-components/etcd-druid/proposals/index.md
@@ -1,9 +1,26 @@
 ---
-title: "Proposals"
+title: Proposals
 auto_generated: true
 generated_by: post-processing/part-3.js addMissingIndexFiles function
 prev: false
 next: false
 editLink: false
 ---
+<!-- BANNER:GENERATED -->
+<!--
+   █▀▀ █▀▀ █▄ █
+   █ █ █▀▀ █ ▀█
+   ▀▀▀ ▀▀▀ ▀  ▀
+
+   ┌────────────────────────────────────────────────┐
+   │  GENERATED FILE — navigation stub              │
+   │                                                │
+   │  Created by post-processing/part-index.js      │
+   │  (addMissingIndexFiles). It has no upstream     │
+   │  source; the aggregation run recreates it.      │
+   │                                                │
+   │  Do not edit and do not commit by hand.         │
+   └────────────────────────────────────────────────┘
+-->
+
 

--- a/hugo/content/docs/other-components/etcd-druid/proposals/index.md
+++ b/hugo/content/docs/other-components/etcd-druid/proposals/index.md
@@ -1,7 +1,7 @@
 ---
 title: Proposals
 auto_generated: true
-generated_by: post-processing/part-3.js addMissingIndexFiles function
+generated_by: post-processing/part-index.js addMissingIndexFiles function
 prev: false
 next: false
 editLink: false

--- a/hugo/content/docs/other-components/etcd-druid/proposals/index.md
+++ b/hugo/content/docs/other-components/etcd-druid/proposals/index.md
@@ -16,10 +16,10 @@ editLink: false
    │  GENERATED FILE — navigation stub              │
    │                                                │
    │  Created by post-processing/part-index.js      │
-   │  (addMissingIndexFiles). It has no upstream     │
-   │  source; the aggregation run recreates it.      │
+   │  (addMissingIndexFiles). It has no upstream    │
+   │  source; the aggregation run recreates it.     │
    │                                                │
-   │  Do not edit and do not commit by hand.         │
+   │  Do not edit and do not commit by hand.        │
    └────────────────────────────────────────────────┘
 -->
 

--- a/hugo/content/docs/other-components/gardener-discovery-server/index.md
+++ b/hugo/content/docs/other-components/gardener-discovery-server/index.md
@@ -10,7 +10,6 @@ path_base_for_github_subdir:
 title: Gardener Discovery Server
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/other-components/machine-controller-manager/documents/index.md
+++ b/hugo/content/docs/other-components/machine-controller-manager/documents/index.md
@@ -11,7 +11,6 @@ title: Documents
 weight: 2
 prev: false
 next: false
-managed: true
 editLink: false
 ---
 <!-- BANNER:MANAGED -->

--- a/hugo/content/docs/other-components/machine-controller-manager/index.md
+++ b/hugo/content/docs/other-components/machine-controller-manager/index.md
@@ -10,7 +10,6 @@ path_base_for_github_subdir:
 title: Machine Controller Manager
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/other-components/machine-controller-manager/proposals/index.md
+++ b/hugo/content/docs/other-components/machine-controller-manager/proposals/index.md
@@ -11,7 +11,6 @@ title: Proposals
 weight: 3
 prev: false
 next: false
-managed: true
 editLink: false
 ---
 <!-- BANNER:MANAGED -->

--- a/hugo/content/docs/other-components/machine-controller-manager/todo/index.md
+++ b/hugo/content/docs/other-components/machine-controller-manager/todo/index.md
@@ -11,7 +11,6 @@ title: To-Do
 weight: 4
 prev: false
 next: false
-managed: true
 editLink: false
 ---
 <!-- BANNER:MANAGED -->

--- a/hugo/content/docs/other-components/network-problem-detector/index.md
+++ b/hugo/content/docs/other-components/network-problem-detector/index.md
@@ -12,7 +12,6 @@ path_base_for_github_subdir:
 title: Network Problem Detector
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0001-gardener-extensibility/index.md
+++ b/hugo/content/docs/proposals/0001-gardener-extensibility/index.md
@@ -9,7 +9,6 @@ path_base_for_github_subdir:
 title: 0001 Gardener Extensibility
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0002-backup-infrastructure/index.md
+++ b/hugo/content/docs/proposals/0002-backup-infrastructure/index.md
@@ -9,7 +9,6 @@ path_base_for_github_subdir:
 title: 0002 Backup Infrastructure
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0003-networking-extensibility/index.md
+++ b/hugo/content/docs/proposals/0003-networking-extensibility/index.md
@@ -9,7 +9,6 @@ path_base_for_github_subdir:
 title: 0003 Networking Extensibility
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0004-core-gardener-cloud-api/index.md
+++ b/hugo/content/docs/proposals/0004-core-gardener-cloud-api/index.md
@@ -9,7 +9,6 @@ path_base_for_github_subdir:
 title: 0004 Core Gardener Cloud Api
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0005-versioning-policy/index.md
+++ b/hugo/content/docs/proposals/0005-versioning-policy/index.md
@@ -9,7 +9,6 @@ path_base_for_github_subdir:
 title: 0005 Versioning Policy
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0006-etcd-druid/index.md
+++ b/hugo/content/docs/proposals/0006-etcd-druid/index.md
@@ -9,7 +9,6 @@ path_base_for_github_subdir:
 title: 0006 Etcd Druid
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0007-shoot-control-plane-migration/index.md
+++ b/hugo/content/docs/proposals/0007-shoot-control-plane-migration/index.md
@@ -9,7 +9,6 @@ path_base_for_github_subdir:
 title: 0007 Shoot Control Plane Migration
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0008-shoot-apiserver-via-sni/index.md
+++ b/hugo/content/docs/proposals/0008-shoot-apiserver-via-sni/index.md
@@ -9,7 +9,6 @@ path_base_for_github_subdir:
 title: 0008 Shoot Apiserver Via Sni
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0009-integration-test-framework/index.md
+++ b/hugo/content/docs/proposals/0009-integration-test-framework/index.md
@@ -9,7 +9,6 @@ path_base_for_github_subdir:
 title: 0009 Integration Test Framework
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0010-container-runtime-extensibility/index.md
+++ b/hugo/content/docs/proposals/0010-container-runtime-extensibility/index.md
@@ -9,7 +9,6 @@ path_base_for_github_subdir:
 title: 0010 Container Runtime Extensibility
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0011-apiserver-network-proxy/index.md
+++ b/hugo/content/docs/proposals/0011-apiserver-network-proxy/index.md
@@ -9,7 +9,6 @@ path_base_for_github_subdir:
 title: 0011 Apiserver Network Proxy
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0012-oidc-webhook-authenticator/index.md
+++ b/hugo/content/docs/proposals/0012-oidc-webhook-authenticator/index.md
@@ -9,7 +9,6 @@ path_base_for_github_subdir:
 title: 0012 Oidc Webhook Authenticator
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0013-automated-seed-management/index.md
+++ b/hugo/content/docs/proposals/0013-automated-seed-management/index.md
@@ -9,7 +9,6 @@ path_base_for_github_subdir:
 title: 0013 Automated Seed Management
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0014-reversed-cluster-vpn/index.md
+++ b/hugo/content/docs/proposals/0014-reversed-cluster-vpn/index.md
@@ -9,7 +9,6 @@ path_base_for_github_subdir:
 title: 0014 Reversed Cluster Vpn
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0015-bastion-management/index.md
+++ b/hugo/content/docs/proposals/0015-bastion-management/index.md
@@ -9,7 +9,6 @@ path_base_for_github_subdir:
 title: 0015 Bastion Management
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0016-adminkubeconfig-subresource/index.md
+++ b/hugo/content/docs/proposals/0016-adminkubeconfig-subresource/index.md
@@ -9,7 +9,6 @@ path_base_for_github_subdir:
 title: 0016 Adminkubeconfig Subresource
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0017-shoot-control-plane-migration-bad-case/index.md
+++ b/hugo/content/docs/proposals/0017-shoot-control-plane-migration-bad-case/index.md
@@ -9,7 +9,6 @@ path_base_for_github_subdir:
 title: 0017 Shoot Control Plane Migration Bad Case
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0018-shoot-ca-rotation/index.md
+++ b/hugo/content/docs/proposals/0018-shoot-ca-rotation/index.md
@@ -9,7 +9,6 @@ path_base_for_github_subdir:
 title: 0018 Shoot Ca Rotation
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0019-observability-stack-operator-migration/index.md
+++ b/hugo/content/docs/proposals/0019-observability-stack-operator-migration/index.md
@@ -9,7 +9,6 @@ path_base_for_github_subdir:
 title: 0019 Observability Stack Operator Migration
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0020-ha-control-planes/index.md
+++ b/hugo/content/docs/proposals/0020-ha-control-planes/index.md
@@ -9,7 +9,6 @@ path_base_for_github_subdir:
 title: 0020 Ha Control Planes
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0021-ipv6-singlestack-local/index.md
+++ b/hugo/content/docs/proposals/0021-ipv6-singlestack-local/index.md
@@ -9,7 +9,6 @@ path_base_for_github_subdir:
 title: 0021 Ipv6 Singlestack Local
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0022-improved-shootstate-usage/index.md
+++ b/hugo/content/docs/proposals/0022-improved-shootstate-usage/index.md
@@ -9,7 +9,6 @@ path_base_for_github_subdir:
 title: 0022 Improved Shootstate Usage
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0023-autoscaling-kube-apiserver-via-independent-hpa-and-vpa/index.md
+++ b/hugo/content/docs/proposals/0023-autoscaling-kube-apiserver-via-independent-hpa-and-vpa/index.md
@@ -10,7 +10,6 @@ path_base_for_github_subdir:
 title: 0023 Autoscaling Kube Apiserver Via Independent Hpa And Vpa
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0024-shoot-oidc-issuer/index.md
+++ b/hugo/content/docs/proposals/0024-shoot-oidc-issuer/index.md
@@ -9,7 +9,6 @@ path_base_for_github_subdir:
 title: 0024 Shoot Oidc Issuer
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0025-namespaced-cloudprofiles/index.md
+++ b/hugo/content/docs/proposals/0025-namespaced-cloudprofiles/index.md
@@ -9,7 +9,6 @@ path_base_for_github_subdir:
 title: 0025 Namespaced Cloudprofiles
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0026-workload-identity/index.md
+++ b/hugo/content/docs/proposals/0026-workload-identity/index.md
@@ -9,7 +9,6 @@ path_base_for_github_subdir:
 title: 0026 Workload Identity
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0027-cloudprofile-bastion-section/index.md
+++ b/hugo/content/docs/proposals/0027-cloudprofile-bastion-section/index.md
@@ -9,7 +9,6 @@ path_base_for_github_subdir:
 title: 0027 Cloudprofile Bastion Section
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0028-self-hosted-shoot-clusters/index.md
+++ b/hugo/content/docs/proposals/0028-self-hosted-shoot-clusters/index.md
@@ -9,7 +9,6 @@ path_base_for_github_subdir:
 title: 0028 Self Hosted Shoot Clusters
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0030-apiserver-proxy/index.md
+++ b/hugo/content/docs/proposals/0030-apiserver-proxy/index.md
@@ -9,7 +9,6 @@ path_base_for_github_subdir:
 title: 0030 Apiserver Proxy
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0031-inplace-node-updates/index.md
+++ b/hugo/content/docs/proposals/0031-inplace-node-updates/index.md
@@ -9,7 +9,6 @@ path_base_for_github_subdir:
 title: 0031 Inplace Node Updates
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0032-version-classification-lifecycle/index.md
+++ b/hugo/content/docs/proposals/0032-version-classification-lifecycle/index.md
@@ -9,7 +9,6 @@ path_base_for_github_subdir:
 title: 0032 Version Classification Lifecycle
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0033-machine-image-capabilities/index.md
+++ b/hugo/content/docs/proposals/0033-machine-image-capabilities/index.md
@@ -9,7 +9,6 @@ path_base_for_github_subdir:
 title: 0033 Machine Image Capabilities
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0034-observability2.0-opentelemetry/index.md
+++ b/hugo/content/docs/proposals/0034-observability2.0-opentelemetry/index.md
@@ -9,7 +9,6 @@ path_base_for_github_subdir:
 title: 0034 Observability2.0 Opentelemetry
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0035-observability2.0-victorialogs/index.md
+++ b/hugo/content/docs/proposals/0035-observability2.0-victorialogs/index.md
@@ -9,7 +9,6 @@ path_base_for_github_subdir:
 title: 0035 Observability2.0 Victorialogs
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0036-self-hosted-shoot-exposure/index.md
+++ b/hugo/content/docs/proposals/0036-self-hosted-shoot-exposure/index.md
@@ -9,7 +9,6 @@ path_base_for_github_subdir:
 title: 0036 Self Hosted Shoot Exposure
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0037-scaling-advisor/index.md
+++ b/hugo/content/docs/proposals/0037-scaling-advisor/index.md
@@ -9,7 +9,6 @@ path_base_for_github_subdir:
 title: 0037 Scaling Advisor
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0038-autoscaling-persistentvolumeclaims/index.md
+++ b/hugo/content/docs/proposals/0038-autoscaling-persistentvolumeclaims/index.md
@@ -9,7 +9,6 @@ path_base_for_github_subdir:
 title: 0038 Autoscaling Persistentvolumeclaims
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0039-live-control-plane-migration/index.md
+++ b/hugo/content/docs/proposals/0039-live-control-plane-migration/index.md
@@ -9,7 +9,6 @@ path_base_for_github_subdir:
 title: 0039 Live Control Plane Migration
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0043-spegel-registry-support-in-the-registry-cache-extension/index.md
+++ b/hugo/content/docs/proposals/0043-spegel-registry-support-in-the-registry-cache-extension/index.md
@@ -10,7 +10,6 @@ path_base_for_github_subdir:
 title: 0043 Spegel Registry Support In The Registry Cache Extension
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0049-gardener-landscape-kit/index.md
+++ b/hugo/content/docs/proposals/0049-gardener-landscape-kit/index.md
@@ -9,7 +9,6 @@ path_base_for_github_subdir:
 title: 0049 Gardener Landscape Kit
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0057-replace-nginx-ingress-shoot-addon-with-traefik-extension/index.md
+++ b/hugo/content/docs/proposals/0057-replace-nginx-ingress-shoot-addon-with-traefik-extension/index.md
@@ -10,7 +10,6 @@ path_base_for_github_subdir:
 title: 0057 Replace Nginx Ingress Shoot Addon With Traefik Extension
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0063-diki-extension/index.md
+++ b/hugo/content/docs/proposals/0063-diki-extension/index.md
@@ -9,7 +9,6 @@ path_base_for_github_subdir:
 title: 0063 Diki Extension
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/0068-gateway-api-extension/index.md
+++ b/hugo/content/docs/proposals/0068-gateway-api-extension/index.md
@@ -9,7 +9,6 @@ path_base_for_github_subdir:
 title: 0068 Gateway Api Extension
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/proposals/index.md
+++ b/hugo/content/docs/proposals/index.md
@@ -10,7 +10,6 @@ title: Proposals
 weight: 34
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/hugo/content/docs/security-and-compliance/index.md
+++ b/hugo/content/docs/security-and-compliance/index.md
@@ -13,7 +13,6 @@ title: Security and Compliance
 weight: 36
 prev: false
 next: false
-managed: true
 ---
 <!-- BANNER:MANAGED -->
 <!--

--- a/post-processing/lib/banner.js
+++ b/post-processing/lib/banner.js
@@ -4,6 +4,7 @@ export { buildUpstreamUrl };
 
 const MARKER_MANAGED = '<!-- BANNER:MANAGED -->';
 const MARKER_LOCAL = '<!-- BANNER:LOCAL -->';
+const MARKER_GENERATED = '<!-- BANNER:GENERATED -->';
 const MARKER_PREFIX = '<!-- BANNER:';
 
 const MANAGED_TEMPLATE = `${MARKER_MANAGED}
@@ -33,7 +34,7 @@ const LOCAL_BANNER = `${MARKER_LOCAL}
    █ █ █▀▄
    ▀▀▀ ▀ ▀
 
-   ┌────────────────────────────────────────────────┐  
+   ┌────────────────────────────────────────────────┐
    │  LOCAL FILE — maintained in gardener/          │
    │  documentation                                 │
    │                                                │
@@ -42,16 +43,37 @@ const LOCAL_BANNER = `${MARKER_LOCAL}
    └────────────────────────────────────────────────┘
 -->`;
 
-// Based solely on frontmatter. github_repo -> managed. Otherwise: editLink:false
-// with an empty body is a docforge navigation stub (skip), everything else is local.
+const GENERATED_BANNER = `${MARKER_GENERATED}
+<!--
+   █▀▀ █▀▀ █▄ █
+   █ █ █▀▀ █ ▀█
+   ▀▀▀ ▀▀▀ ▀  ▀
+
+   ┌────────────────────────────────────────────────┐
+   │  GENERATED FILE — navigation stub              │
+   │                                                │
+   │  Created by post-processing/part-index.js      │
+   │  (addMissingIndexFiles). It has no upstream     │
+   │  source; the aggregation run recreates it.      │
+   │                                                │
+   │  Do not edit and do not commit by hand.         │
+   └────────────────────────────────────────────────┘
+-->`;
+
+// Based solely on frontmatter. github_repo -> managed (upstream source of truth).
+// auto_generated -> generated (a navigation stub written by part-index.js, no
+// upstream). Then: editLink:false with an empty body is a docforge navigation
+// stub (skip), everything else is local.
 export function classify(data, content) {
   if (data.github_repo) return 'managed';
+  if (data.auto_generated) return 'generated';
   if (data.editLink === false && content.trim().length === 0) return 'skip';
   return 'local';
 }
 
 export function renderBanner(kind, url) {
   if (kind === 'managed') return MANAGED_TEMPLATE.replace('{upstreamUrl}', url);
+  if (kind === 'generated') return GENERATED_BANNER;
   return LOCAL_BANNER;
 }
 
@@ -68,7 +90,7 @@ export function injectBanner(content, bannerBlock) {
 // from the remaining content. This lets the content analysis ignore the banner.
 export function splitLeadingBanner(content) {
   const match = content.match(
-    /^\s*(<!-- BANNER:(?:MANAGED|LOCAL) -->\r?\n<!--[\s\S]*?-->)\s*/,
+    /^\s*(<!-- BANNER:(?:MANAGED|LOCAL|GENERATED) -->\r?\n<!--[\s\S]*?-->)\s*/,
   );
   if (!match) return { banner: null, rest: content };
   return { banner: match[1], rest: content.slice(match.index + match[0].length) };

--- a/post-processing/lib/banner.js
+++ b/post-processing/lib/banner.js
@@ -53,10 +53,10 @@ const GENERATED_BANNER = `${MARKER_GENERATED}
    │  GENERATED FILE — navigation stub              │
    │                                                │
    │  Created by post-processing/part-index.js      │
-   │  (addMissingIndexFiles). It has no upstream     │
-   │  source; the aggregation run recreates it.      │
+   │  (addMissingIndexFiles). It has no upstream    │
+   │  source; the aggregation run recreates it.     │
    │                                                │
-   │  Do not edit and do not commit by hand.         │
+   │  Do not edit and do not commit by hand.        │
    └────────────────────────────────────────────────┘
 -->`;
 

--- a/post-processing/lib/banner.test.js
+++ b/post-processing/lib/banner.test.js
@@ -38,6 +38,27 @@ test('classify: editLink false but body present -> local', () => {
   assert.equal(classify({ editLink: false }, '# Real content\n'), 'local');
 });
 
+test('classify: auto_generated stub -> generated', () => {
+  assert.equal(
+    classify({ auto_generated: true, editLink: false }, '\n'),
+    'generated',
+  );
+});
+
+test('classify: auto_generated wins even after banner injected (non-empty body)', () => {
+  assert.equal(
+    classify({ auto_generated: true, editLink: false }, '<!-- BANNER:GENERATED -->\n'),
+    'generated',
+  );
+});
+
+test('classify: auto_generated never overrides managed', () => {
+  assert.equal(
+    classify(managedData({ auto_generated: true }), '# Body\n'),
+    'managed',
+  );
+});
+
 // --- buildUpstreamUrl ---
 
 test('buildUpstreamUrl: correct deep link', () => {
@@ -123,6 +144,13 @@ test('renderBanner: local contains marker, static', () => {
   assert.match(block, /source of truth/);
 });
 
+test('renderBanner: generated contains marker, static, no upstream url', () => {
+  const block = renderBanner('generated', null);
+  assert.match(block, /^<!-- BANNER:GENERATED -->/);
+  assert.doesNotMatch(block, /\{upstreamUrl\}/);
+  assert.doesNotMatch(block, /http/);
+});
+
 test('renderBanner: no surrounding whitespace', () => {
   const block = renderBanner('local', null);
   assert.equal(block, block.trim());
@@ -136,6 +164,10 @@ test('hasBanner: detects MANAGED marker', () => {
 
 test('hasBanner: detects LOCAL marker', () => {
   assert.equal(hasBanner('<!-- BANNER:LOCAL -->\n<!-- x -->\n# Body'), true);
+});
+
+test('hasBanner: detects GENERATED marker', () => {
+  assert.equal(hasBanner('<!-- BANNER:GENERATED -->\n<!-- x -->\n# Body'), true);
 });
 
 test('hasBanner: false on banner-less content', () => {
@@ -176,6 +208,13 @@ test('splitLeadingBanner: no banner -> banner null, rest unchanged', () => {
 test('splitLeadingBanner: leading whitespace before banner is tolerated', () => {
   const block = renderBanner('managed', 'https://example.com/x.md');
   const { banner, rest } = splitLeadingBanner(`\n\n${block}\n\n# Body\n`);
+  assert.equal(banner, block);
+  assert.equal(rest, '# Body\n');
+});
+
+test('splitLeadingBanner: splits leading GENERATED banner', () => {
+  const block = renderBanner('generated', null);
+  const { banner, rest } = splitLeadingBanner(`${block}\n\n# Body\n`);
   assert.equal(banner, block);
   assert.equal(rest, '# Body\n');
 });

--- a/post-processing/lib/image-refs.js
+++ b/post-processing/lib/image-refs.js
@@ -9,7 +9,12 @@
 //
 // Two syntaxes are covered: Markdown ![alt](/path/File.png) and inline HTML
 // <img src="/path/File.png">, since upstream docs mix both.
-const IMAGE_REF = /(!\[[^\]]*\]\()(\/[^):]*?)([^/):]+\.(?:png|jpg|jpeg|svg|webp))(\))/gi;
+//
+// The Markdown form also allows an optional title after the path, e.g.
+// ![alt](/path/File.png "Title") or with single quotes. The title is captured
+// as part of the closing group so it survives untouched while the filename is
+// lowercased.
+const IMAGE_REF = /(!\[[^\]]*\]\()(\/[^\s):]*?)([^/\s):]+\.(?:png|jpg|jpeg|svg|webp))((?:\s+(?:"[^"]*"|'[^']*'))?\))/gi;
 const HTML_IMG_REF = /(<img\b[^>]*?\bsrc=["'])(\/[^"']*?)([^/"']+\.(?:png|jpg|jpeg|svg|webp))(["'])/gi;
 
 export function lowercaseImageRefs(content) {

--- a/post-processing/lib/image-refs.js
+++ b/post-processing/lib/image-refs.js
@@ -14,7 +14,7 @@
 // ![alt](/path/File.png "Title") or with single quotes. The title is captured
 // as part of the closing group so it survives untouched while the filename is
 // lowercased.
-const IMAGE_REF = /(!\[[^\]]*\]\()(\/[^\s):]*?)([^/\s):]+\.(?:png|jpg|jpeg|svg|webp))((?:\s+(?:"[^"]*"|'[^']*'))?\))/gi;
+const IMAGE_REF = /(!\[[^\]]*\]\()(\/[^\s):]*?)([^/\s):]+\.(?:png|jpg|jpeg|svg|webp))((?:\s+(?:"[^"]*"|'[^']*'))?\s*\))/gi;
 const HTML_IMG_REF = /(<img\b[^>]*?\bsrc=["'])(\/[^"']*?)([^/"']+\.(?:png|jpg|jpeg|svg|webp))(["'])/gi;
 
 export function lowercaseImageRefs(content) {

--- a/post-processing/lib/image-refs.test.js
+++ b/post-processing/lib/image-refs.test.js
@@ -97,3 +97,24 @@ test('HTML img already lowercase is a no-op', () => {
   const out = lowercaseImageRefs(input);
   assert.equal(out, input);
 });
+
+// 12. Markdown image with a double-quoted title still lowercases the filename.
+test('lowercases filename with double-quoted markdown title', () => {
+  const input = '![alt](/docs/proposals/0014-reversed-cluster-vpn/CurrentClusterVPN.png "Overview Current Cluster VPN")';
+  const out = lowercaseImageRefs(input);
+  assert.equal(out, '![alt](/docs/proposals/0014-reversed-cluster-vpn/currentclustervpn.png "Overview Current Cluster VPN")');
+});
+
+// 13. Markdown image with a single-quoted title still lowercases the filename.
+test('lowercases filename with single-quoted markdown title', () => {
+  const input = "![alt](/docs/assets/MyDiagram.png 'A Title')";
+  const out = lowercaseImageRefs(input);
+  assert.equal(out, "![alt](/docs/assets/mydiagram.png 'A Title')");
+});
+
+// 14. Title present but filename already lowercase is a no-op (idempotency).
+test('titled reference already lowercase is a no-op', () => {
+  const input = '![alt](/docs/assets/diagram.png "Title")';
+  const out = lowercaseImageRefs(input);
+  assert.equal(out, input);
+});

--- a/post-processing/lib/image-refs.test.js
+++ b/post-processing/lib/image-refs.test.js
@@ -118,3 +118,10 @@ test('titled reference already lowercase is a no-op', () => {
   const out = lowercaseImageRefs(input);
   assert.equal(out, input);
 });
+
+// 15. Uppercase extension with title and trailing whitespace before ')'.
+test('lowercases filename with uppercase extension, title and trailing space', () => {
+  const input = '![alt](/docs/assets/MyDiagram.PNG "A Title" )';
+  const out = lowercaseImageRefs(input);
+  assert.equal(out, '![alt](/docs/assets/mydiagram.png "A Title" )');
+});

--- a/post-processing/part-banner.js
+++ b/post-processing/part-banner.js
@@ -52,6 +52,7 @@ function main() {
 
     let managed = 0;
     let local = 0;
+    let generated = 0;
     let skipped = 0;
     let written = 0;
 
@@ -64,6 +65,7 @@ function main() {
         continue;
       }
       if (kind === 'managed') managed += 1;
+      else if (kind === 'generated') generated += 1;
       else local += 1;
 
       if (hasBanner(content)) continue;
@@ -75,7 +77,7 @@ function main() {
     }
 
     console.log(
-      `Processed ${files.length} files (${managed} managed, ${local} local, ${skipped} skipped, ${written} written)`,
+      `Processed ${files.length} files (${managed} managed, ${local} local, ${generated} generated, ${skipped} skipped, ${written} written)`,
     );
   } catch (error) {
     console.error('Error:', error.message);

--- a/post-processing/select-banner-files.mjs
+++ b/post-processing/select-banner-files.mjs
@@ -1,0 +1,40 @@
+import { read } from './lib/frontmatter.js';
+import { splitLeadingBanner } from './lib/banner.js';
+
+// Reads NUL-delimited candidate paths from stdin and prints back, NUL-delimited,
+// only the files whose body begins with a MANAGED or GENERATED banner. This
+// mirrors post-processing/part-1.js: parse frontmatter, then run
+// splitLeadingBanner on the body so a marker buried in prose or a fenced code
+// block never counts. LOCAL banners are the source of truth and are excluded.
+
+const MANAGED_OR_GENERATED = /^<!-- BANNER:(?:MANAGED|GENERATED) -->/;
+
+function hasLeadingManagedBanner(filePath) {
+  let parsed;
+  try {
+    parsed = read(filePath);
+  } catch {
+    // Unreadable or invalid YAML: not a validatable banner file, so skip it.
+    return false;
+  }
+  const { banner } = splitLeadingBanner(parsed.content.trimStart());
+  return banner !== null && MANAGED_OR_GENERATED.test(banner);
+}
+
+async function readStdin() {
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  return Buffer.concat(chunks).toString('utf-8');
+}
+
+const raw = await readStdin();
+// GNU grep -Z separates with NUL; BSD/macOS grep -l ignores -Z and separates
+// with newlines. Split on either so the helper works with both greps.
+const candidates = raw.split(/\0|\r?\n/).filter((p) => p.length > 0);
+
+const out = [];
+for (const filePath of candidates) {
+  if (hasLeadingManagedBanner(filePath)) out.push(filePath);
+}
+
+if (out.length > 0) process.stdout.write(out.join('\0') + '\0');

--- a/post-processing/select-banner-files.mjs
+++ b/post-processing/select-banner-files.mjs
@@ -9,7 +9,7 @@ import { splitLeadingBanner } from './lib/banner.js';
 
 const MANAGED_OR_GENERATED = /^<!-- BANNER:(?:MANAGED|GENERATED) -->/;
 
-function hasLeadingManagedBanner(filePath) {
+function hasLeadingManagedOrGeneratedBanner(filePath) {
   let parsed;
   try {
     parsed = read(filePath);
@@ -34,7 +34,7 @@ const candidates = raw.split(/\0|\r?\n/).filter((p) => p.length > 0);
 
 const out = [];
 for (const filePath of candidates) {
-  if (hasLeadingManagedBanner(filePath)) out.push(filePath);
+  if (hasLeadingManagedOrGeneratedBanner(filePath)) out.push(filePath);
 }
 
 if (out.length > 0) process.stdout.write(out.join('\0') + '\0');


### PR DESCRIPTION
**How to categorize this PR?**

/kind enhancement

**What this PR does / why we need it**:

Bundles post-processing improvements for the docs aggregation pipeline:

- Mark generated index stubs with a `GENERATED` banner
- Remove md-less directories after banner cleanup
- Add docforge managed-file cleanup step (reaper)
- Refine `full-refresh` into `hugo-refresh`
- Fix image path capturing so Markdown refs with a title (`![alt](/path/File.png "Title")`) also get their filename lowercased, matching the physical asset

**Which issue(s) this PR fixes**:
Fixes # https://github.com/gardener/documentation/issues/1071

**Special notes for your reviewer**:
Draft. Content aggregation commits are intentionally excluded; only pipeline/code changes are here.

### Staged content changes are upstream, not pipeline noise

Running `make hugo-refresh` on this branch surfaces staged changes under `hugo/content/`. These are **not** artifacts of the pipeline changes in this PR. They are real upstream source-doc changes that the next aggregation run would pull in regardless of this PR. Each one traces to a specific upstream commit:

| Generated file(s) | Upstream repo | Change | Commit | Date | PR |
|---|---|---|---|---|---|
| `docs/gardener/concepts/operator.md` | gardener/gardener | `clusterTypes` block added, `enabled: true` removed | [`a469fd1`](https://github.com/gardener/gardener/commit/a469fd1f73495102a1a358290d32906cbc27fa7a) | 2026-09-07 | [#15566](https://github.com/gardener/gardener/pull/15566) |
| `docs/gardener/extensions/registration.md` | gardener/gardener | same (garden + seed deployment examples) | [`a469fd1`](https://github.com/gardener/gardener/commit/a469fd1f73495102a1a358290d32906cbc27fa7a) | 2026-09-07 | [#15566](https://github.com/gardener/gardener/pull/15566) |
| `docs/gardener/index.md` | gardener/gardener | "Status Subresource in Gardener APIs" link added | [`0f09833`](https://github.com/gardener/gardener/commit/0f0983359e6801e6498c0cd06d476bcae3f0df08) | 2026-08-28 | [#15527](https://github.com/gardener/gardener/pull/15527) |
| alicloud `index.md` (docs + contribute) | gardener/gardener-extension-provider-alicloud | K8s 1.36 row added, `Kuberneter` typo fixed | [`1602aba`](https://github.com/gardener/gardener-extension-provider-alicloud/commit/1602aba3f08435dc8467b693e0ba8ebc733ad7ec) | 2026-09-01 | [#933](https://github.com/gardener/gardener-extension-provider-alicloud/pull/933) |
| stackit `index.md` + `cloudprovider.md` (deleted) | stackitcloud/gardener-extension-provider-stackit | workflow links restructured, `cloudprovider.md` removed | [`e9ad9b2`](https://github.com/stackitcloud/gardener-extension-provider-stackit/commit/e9ad9b2592c2d0ef02d40a1bfdfa2aaf183926bb) | 2026-09-03 | [#278](https://github.com/stackitcloud/gardener-extension-provider-stackit/pull/278) |
| traefik `index.md`, `ingress-providers.md`, `api-reference`, contribute `index.md` | gardener/gardener-extension-shoot-traefik | providerConfig API flattened `v1alpha1`→`v1alpha2` | [`4947120`](https://github.com/gardener/gardener-extension-shoot-traefik/commit/4947120f) | 2026-09-07 | [#120](https://github.com/gardener/gardener-extension-shoot-traefik/pull/120) |
| traefik `ingress-providers.md` (TLS section) | gardener/gardener-extension-shoot-traefik | "Serving an Ingress over TLS" section added | [`17e5b3c`](https://github.com/gardener/gardener-extension-shoot-traefik/commit/17e5b3c1) | 2026-09-07 | [#146](https://github.com/gardener/gardener-extension-shoot-traefik/pull/146) |

`git status` on this branch:

```
On branch feature/post-processing-generated-banner-cleanup

Changes to be committed:
	modified:   hugo/content/contribute/extensions/gardener-extension-shoot-traefik/index.md
	modified:   hugo/content/contribute/extensions/infrastructure-extensions/gardener-extension-provider-alicloud/index.md
	modified:   hugo/content/docs/extensions/infrastructure-extensions/gardener-extension-provider-alicloud/index.md
	deleted:    hugo/content/docs/extensions/infrastructure-extensions/gardener-extension-provider-stackit/cloudprovider.md
	modified:   hugo/content/docs/extensions/infrastructure-extensions/gardener-extension-provider-stackit/index.md
	modified:   hugo/content/docs/extensions/others/gardener-extension-shoot-traefik/api-reference/traefik.extensions.gardener.cloud.md
	modified:   hugo/content/docs/extensions/others/gardener-extension-shoot-traefik/index.md
	modified:   hugo/content/docs/extensions/others/gardener-extension-shoot-traefik/ingress-providers.md
	modified:   hugo/content/docs/gardener/concepts/operator.md
	modified:   hugo/content/docs/gardener/extensions/registration.md
	modified:   hugo/content/docs/gardener/index.md
```

Note on stackit: upstream uses nested paths (`docs/usage/usage.md` etc.); the post-processing pipeline flattens them to `usage.md`, `operations.md`, etc. That flattening is expected pipeline behavior, not a discrepancy.

### How to test

1. Check out this branch:
   ```
   git checkout feature/post-processing-generated-banner-cleanup && make install
   ```
2. Run a full aggregation + post-process cycle and inspect the result:
   ```
   make hugo-refresh
   git status
   ```
   Every staged file should trace to one of the upstream commits in the table above (besides any newer upstream changes that may have landed in the meantime). Nothing else should appear. Running it again without any manifest edit is idempotent: the staged set stays identical.

3. Confirm that manifest edits are accurately reflected. Make one of the changes below in `.docforge/`, re-run `make hugo-refresh`, and check `git status` shows exactly the corresponding effect. Revert the manifest edit afterwards and re-run to return to the state from step 2.

   All examples target `.docforge/documentation/gardener-extensions/others.yaml`; the effects below were verified end-to-end.

   **a) Exclude a file** — add to the traefik `excludeFiles`:
   ```yaml
   - fileTree: https://github.com/gardener/gardener-extension-shoot-traefik/tree/main/docs
     excludeFiles:
       - "development/"
       - "usage/ingress-providers.md"   # <-- add
   ```
   → `hugo/content/docs/extensions/others/gardener-extension-shoot-traefik/ingress-providers.md` is deleted (reaper removes the orphaned managed file).

   **b) Add a new `dir` block** — a new extension directory:
   ```yaml
   - dir: gardener-extension-scenario-test-copy
     structure:
     - file: _index.md
       frontmatter:
         title: Scenario Test Copy
         description: temporary manifest test entry
       source: https://github.com/gardener/gardener-extension-shoot-traefik/blob/main/README.md
   ```
   → a new `gardener-extension-scenario-test-copy/index.md` is created, carrying a `GENERATED`/`MANAGED` banner.

   **c) Remove a `dir` block** — delete an existing extension block (e.g. `gardener-extension-shoot-networking-filter`).
   → exactly that extension's generated files are deleted, nothing else.

   **d) Change a title** — edit a `frontmatter.title`, e.g. traefik `Traefik Ingress` → `Traefik Ingress Controller`.
   → only the `title:` line in that extension's generated `index.md` changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generated documentation now receives clear banners and is tracked separately in processing summaries.
  * Content refresh workflows clean up managed and generated banners before regeneration and stage refreshed content for review.
  * Banner detection now avoids false matches in prose and code blocks.

* **Bug Fixes**
  * Improved handling of Markdown image references with quoted titles, uppercase extensions, and whitespace before closing parentheses.

* **Documentation**
  * Updated guidance explains content aggregation, banner types, workflows, and refreshed contributor commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

